### PR TITLE
chore: drop google web store upload

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,37 +44,3 @@ jobs:
 
           done
           set -e
-
-      - name: Setup Google Auth 🔧
-        id: auth
-        # yamllint disable-line rule:line-length
-        # nosemgrep: yaml.github-actions.security.third-party-action-not-pinned-to-commit-sha.third-party-action-not-pinned-to-commit-sha
-        uses: google-github-actions/auth@v2
-        with:
-          # yamllint disable-line rule:line-length
-          workload_identity_provider: projects/306279023132/locations/global/workloadIdentityPools/github/providers/github
-          service_account: github-actions@chrome-web-store-api-435512.iam.gserviceaccount.com
-          token_format: access_token
-
-      - name: Upload to Google Web Store
-        env:
-          VERSION: ${{ github.event.release.tag_name }}
-          GOOGLE_CHROME_WEBSTORE_APP_ID: ${{ secrets.GOOGLE_CHROME_WEBSTORE_APP_ID }}
-          GOOGLE_CHROME_WEBSTORE_TOKEN: ${{ steps.auth.outputs.access_token }}
-        run: |
-            name="mergify-chrome-${VERSION}.zip"
-            curl \
-              -v \
-              --fail \
-              -H "Authorization: Bearer ${GOOGLE_CHROME_WEBSTORE_TOKEN}"  \
-              -H "x-goog-api-version: 2" \
-              -X PUT \
-              -T "$name" \
-              "https://www.googleapis.com/upload/chromewebstore/v1.1/items/${GOOGLE_CHROME_WEBSTORE_APP_ID}"
-            curl -v \
-              --fail \
-              -H "Authorization: Bearer $GOOGLE_CHROME_WEBSTORE_TOKEN"  \
-              -H "x-goog-api-version: 2" \
-              -H "Content-Length: 0" \
-              -X POST \
-              "https://www.googleapis.com/chromewebstore/v1.1/items/${GOOGLE_CHROME_WEBSTORE_APP_ID}/publish"


### PR DESCRIPTION
We can't use a service account to do the upload.
The API requires a Google Account logged via an OAuth2
application. This means storing the refresh_token of my
account (or another REAL google account) in GitHub Action and manually
update it when it expires.

Fixes MRGFY-4062