### PR TITLE
fix: detect mergify is enabled with new mergebox

### DIFF
--- a/src/mergify.js
+++ b/src/mergify.js
@@ -226,8 +226,9 @@ function tryInject() {
     if (!isGitHubPullRequestPage()) {
         return
     }
-    
-    var isMergifyEnabledOnTheRepo = document.querySelector('a[href="/apps/mergify"]')
+
+    const appIconUrl = "https://avatars.githubusercontent.com/in/10562"
+    var isMergifyEnabledOnTheRepo = document.querySelector(`img[src^="${appIconUrl}?"]`)
     if (!isMergifyEnabledOnTheRepo) {
         return
     }


### PR DESCRIPTION
The `<a href="/apps/mergify">` element is not present in the new mergebox, however the mergify icon is present in both mergeboxes.

Fixes #29 (for real)

<!--

## Checklists (Just for information, delete me before creating the pull requests)

- [ ]  All checks must pass (Semantic Pull Request, pep8, requirements, unit tests, functional tests, security checks, …)
- [ ]  The code changed/added as part of this pull request must be covered with tests
- [ ]  Hotfixes must have a link to Sentry issue and the `hotfix` label
- [ ]  Features and fixes must have a link to a Linear task
- [ ]  Features must have changes in docs/
- [ ]  Features must have changes in releasenotes/notes/
- [ ]  User facing bug must have changed in releasenotes/nodes/
- [ ]  Pull request must have been reviewed by at least one core reviewer
- [ ]  No pending `requested changes`
- [ ]  No `unresolved threads`
- [ ]  Change that requires manual deployment steps or deployment monitoring requires `manual merge` label until the author is ready to do the deployment.

-->
