### PR TITLE
fix: inject buttons in the right place

### DIFF
--- a/src/mergify.js
+++ b/src/mergify.js
@@ -243,9 +243,10 @@ function tryInject() {
         // Classic merge box
         detailSection.insertBefore(buildMergifySectionForClassicMergeBox(), detailSection.firstChild)
     } else {
-        // New merge box
-        var detailSection = document.querySelector("div.border:nth-child(2)")
-        if (detailSection) {
+        // New merge box (parent div of the conflict section, which is always present)
+        var conflictSection = document.querySelector("section[aria-label=Conflicts")
+        if (conflictSection) {
+            var detailSection = conflictSection.parentElement
             detailSection.insertBefore(buildMergifySectionForNewMergeBox(), detailSection.firstChild)
         }
     }


### PR DESCRIPTION
The new merge box selector is too generic. We have to select a section with a precise selector. The conflict section is always injected so we can select it and get the parent element to inject Mergify's buttons.

Fixes MRGFY-4504
Fixes #33