### PR TITLE
fix: improve how we detect that the PR is managed by Mergify

### DIFF
--- a/src/mergify.js
+++ b/src/mergify.js
@@ -247,7 +247,7 @@ function tryInject() {
     }
 
     const appIconUrl = "https://avatars.githubusercontent.com/in/10562"
-    var isMergifyEnabledOnTheRepo = document.querySelector(`img[src^="${appIconUrl}?"]`)
+    var isMergifyEnabledOnTheRepo = document.querySelector(`img[src^="${appIconUrl}?"][alt="Summary"], img[src^="${appIconUrl}?"][alt="Mergify Merge Protections"]`)
     if (!isMergifyEnabledOnTheRepo) {
         return
     }


### PR DESCRIPTION
The former implementation can detect any Mergify App icon in the page, even if the PR has been referenced by another one. We have to look for the "Summary" or the "Merge Protections" check-run.

Fixes MRGFY-4553