### PR TITLE
fix: improve how we detect that the PR is managed by Mergify

### DIFF
--- a/src/mergify.js
+++ b/src/mergify.js
@@ -247,7 +247,7 @@ function tryInject() {
     }
 
     const appIconUrl = "https://avatars.githubusercontent.com/in/10562"
-    var isMergifyEnabledOnTheRepo = document.querySelector(`img[src^="${appIconUrl}?"][alt="Summary"], img[src^="${appIconUrl}?"][alt="Mergify Merge Protections"]`)
+    var isMergifyEnabledOnTheRepo = document.querySelector(`img[src^="${appIconUrl}?"][alt="Summary"], img[src^="${appIconUrl}?"][alt="Mergify Merge Protections"], a[href="/apps/mergify"] img[src^="${appIconUrl}?"]`)
     if (!isMergifyEnabledOnTheRepo) {
         return
     }


### PR DESCRIPTION
The previous fix doesn't work on the old GitHub UI because the check-runs aren't built the same way. This PR adds a new way to find Mergify's icon on the page.

Fixes MRGFY-4595