### PR TITLE
chore: add alias to run jest

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,4 +42,4 @@ jobs:
       - name: Test
         run: |
           make
-          npx jest
+          npm run test

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,10 @@
 {
-  "name": "expanded-check-container",
+  "name": "mergify-browser-extension",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
+      "name": "mergify-browser-extension",
       "devDependencies": {
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0"

--- a/package.json
+++ b/package.json
@@ -1,4 +1,8 @@
 {
+  "name": "mergify-browser-extension",
+  "scripts": {
+    "test": "jest"
+  },
   "devDependencies": {
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0"


### PR DESCRIPTION
This adds `npm run test` script to run jest.

This run the jest installed in node_modules instead of downloading
another one with npx.