### PR TITLE
feat: include pull request number in merge queue link

### DIFF
--- a/src/mergify.js
+++ b/src/mergify.js
@@ -104,7 +104,7 @@ function getEventLogLink() {
 
 function getMergeQueueLink() {
     const data = getPullRequestData();
-    return `https://dashboard.mergify.com/queues?login=${data.org}&repository=${data.repo}&branch=main`;
+    return `https://dashboard.mergify.com/queues?login=${data.org}&repository=${data.repo}&branch=main&pull-request-number=${data.pull}`;
 }
 
 function buildMergifySectionForClassicMergeBox() {


### PR DESCRIPTION
We need to send the pull request number to the merge queue page from the URL, so the dashboard will be able to trace which PR have been clicked.

Related to MRGFY-5023