### PR TITLE
ci: use `gsed` instead of `sed`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,6 @@ jobs:
         run: |
           npm ci
           brew install gnu-sed
-          echo "$(brew --prefix)/opt/gnu-sed/libexec/gnubin" >> "$GITHUB_PATH"
       
       - name: Test
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,6 @@ jobs:
           VERSION: ${{ github.event.release.tag_name }}
         run: |
           brew install gnu-sed
-          echo "$(brew --prefix)/opt/gnu-sed/libexec/gnubin" >> "$GITHUB_PATH"
 
           sudo xcode-select -s /Applications/Xcode.app
           make

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ mergify-%-${VERSION}.zip: %
 	rm -rf build $@
 	cp -a src build
 	rm -rf build/__tests__
-	sed -i \
+	gsed -i \
 		-e 's/#VERSION#/$(VERSION)/g' \
 		-e 's/$(GITHUB_DOMAIN_DEFAULT)/$(GITHUB_DOMAIN)/g' \
 		-e 's/$(MERGIFY_DOMAIN_DEFAULT)/$(MERGIFY_DOMAIN)/g' \


### PR DESCRIPTION
We get this warning when installing `gnu-sed` in the CI:

```
GNU "sed" has been installed as "gsed".
If you need to use it as "sed", you can add a "gnubin" directory
to your PATH from your bashrc like:

    PATH="/opt/homebrew/opt/gnu-sed/libexec/gnubin:$PATH"
```

Changing the GitHub's path using `echo "$(brew --prefix)/opt/gnu-sed/libexec/gnubin" >> "$GITHUB_PATH"` doesn't work. We can use `gsed` to fix the issue.