### PR TITLE
fix: remove unwanted exports

### DIFF
--- a/src/mergify.js
+++ b/src/mergify.js
@@ -411,4 +411,7 @@ class MergifyCache {
     });
 })();
 
-module.exports = { MergifyCache, findNewMergeBox };
+// Required for testing only, module does not exists in an extension
+try {
+    module.exports = { MergifyCache, findNewMergeBox };
+} catch (e) {}


### PR DESCRIPTION
The extension emits some exceptions because the package is not a module,
just a script.

> Uncaught ReferenceError: module is not defined

Their is nothing to export in the main script.