### PR TITLE
fix: read PR state in class attribute

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
     testEnvironment: "jsdom",
     roots: ["<rootDir>/src"],
+    testMatch: ["**/*.test.js"],
 };

--- a/src/__tests__/mergify.test.js
+++ b/src/__tests__/mergify.test.js
@@ -1,6 +1,5 @@
-const { MergifyCache, findNewMergeBox } = require("../mergify");
-const fs = require("node:fs");
-const path = require("node:path");
+const { MergifyCache, findNewMergeBox, getPullStatus } = require("../mergify");
+const { loadFixture } = require("./utils");
 
 describe("MergifyCache", () => {
     beforeEach(() => {
@@ -63,13 +62,6 @@ describe("MergifyCache", () => {
 });
 
 describe("findNewMergeBox", () => {
-    function loadFixture(name) {
-        const htmlPath = path.resolve(__dirname, `./fixtures/${name}.html`);
-        const htmlContent = fs.readFileSync(htmlPath, "utf8");
-
-        document.body.innerHTML = htmlContent;
-    }
-
     afterEach(() => {
         document.body.innerHTML = "";
     });
@@ -95,5 +87,27 @@ describe("findNewMergeBox", () => {
         expect(mergeBox.innerHTML).toMatch(
             /Pull\s+request\s+successfully\s+merged\s+and\s+closed/,
         );
+    });
+});
+
+describe("getPullStatus", () => {
+    afterEach(() => {
+        document.body.innerHTML = "";
+    });
+
+    it("should get opened pull request status", () => {
+        loadFixture("github_pr_opened");
+
+        const status = getPullStatus();
+
+        expect(status).toBe("open");
+    });
+
+    it("should get opened pull request status", () => {
+        loadFixture("github_pr_merged");
+
+        const status = getPullStatus();
+
+        expect(status).toBe("merged");
     });
 });

--- a/src/__tests__/utils.js
+++ b/src/__tests__/utils.js
@@ -1,0 +1,13 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+function loadFixture(name) {
+    const htmlPath = path.resolve(__dirname, `./fixtures/${name}.html`);
+    const htmlContent = fs.readFileSync(htmlPath, "utf8");
+
+    document.body.innerHTML = htmlContent;
+}
+
+module.exports = {
+    loadFixture,
+};

--- a/src/mergify.js
+++ b/src/mergify.js
@@ -95,14 +95,14 @@ function postCommand(command) {
 function getPullStatus() {
     const status = document
         .querySelector("span.State")
-        .getAttribute("title")
-        .replace("Status: ", "");
+        .getAttribute("class")
+        .split("--")[1];
     if (!status) {
         console.warn("Can't find pull request status");
         // Assume it's open if we can't find the status
-        return "Open";
+        return "open";
     }
-    // status can be "Open", "Merged" or "Closed"
+    // status can be "open", "merged" or "closed"
     return status;
 }
 
@@ -178,7 +178,7 @@ function buildMergifySectionForClassicMergeBox() {
           <a class="Link--inTextBlock btn-link" href="${getEventLogLink()}" target="_blank">View event logs of the pull request.</a>
     `;
 
-    const pullIsClosed = getPullStatus() !== "Open";
+    const pullIsClosed = getPullStatus() !== "open";
 
     const btnbox = document.createElement("div");
     btnbox.style.float = "right";
@@ -284,7 +284,7 @@ function buildButton(command, label, tooltip, disabled) {
 }
 
 function buildTitleAndButtonsContainer() {
-    const pullIsClosed = getPullStatus() !== "Open";
+    const pullIsClosed = getPullStatus() !== "open";
 
     const container = document.createElement("div");
     container.className = "d-flex flex-1 flex-column flex-sm-row gap-2";
@@ -462,5 +462,5 @@ class MergifyCache {
 
 // Required for testing only, module does not exists in an extension
 try {
-    module.exports = { MergifyCache, findNewMergeBox };
+    module.exports = { MergifyCache, findNewMergeBox, getPullStatus };
 } catch (e) {}


### PR DESCRIPTION
Currently, we get the state from the label. This label can be translated. We should get it from something that cannot change, like the class.

Fixes MRGFY-5120