### PR TITLE
fix(extension): resolve sticky-offset overlap, Files-tab discovery, and missed PR-feedback fixes

### DIFF
--- a/src/__tests__/mergify.test.js
+++ b/src/__tests__/mergify.test.js
@@ -1303,6 +1303,35 @@ describe("gatherPrStatuses", () => {
         await gatherPrStatuses(items, cache, () => {}, 3);
         expect(peak).toBeLessThanOrEqual(3);
     });
+
+    it("dedupes concurrent fetches for the same PR (org/repo/num/head_sha)", async () => {
+        const cache = new PrStatusCache();
+        let resolveFetch;
+        let fetchCallCount = 0;
+        global.fetch = jest.fn(() => {
+            fetchCallCount += 1;
+            return new Promise((res) => {
+                resolveFetch = () =>
+                    res({
+                        ok: true,
+                        text: () =>
+                            Promise.resolve(
+                                '<span data-status="pullOpened"></span>',
+                            ),
+                    });
+            });
+        });
+        const items = [{ org: "o", repo: "r", num: 1, head_sha: "h" }];
+        const p1 = gatherPrStatuses(items, cache, () => {});
+        const p2 = gatherPrStatuses(items, cache, () => {});
+        await Promise.resolve();
+        await Promise.resolve();
+        // Two concurrent gathers for the same PR → only one network fetch.
+        expect(fetchCallCount).toBe(1);
+        resolveFetch();
+        await p1;
+        await p2;
+    });
 });
 
 describe("buildContextPanel", () => {
@@ -2079,6 +2108,172 @@ describe("renderMergifyContext", () => {
         expect(document.querySelector("#mergify-context")).toBeNull();
     });
 
+    it("backs off after an edit_form failure (negative cache)", async () => {
+        document.body.innerHTML =
+            '<div id="discussion_bucket"></div>' +
+            '<div class="TimelineItem">' +
+            '<div id="issuecomment-1"></div>' +
+            '<div class="comment-body">Mergify stack</div>' +
+            "</div>";
+        const fetchSpy = jest.fn(() =>
+            Promise.resolve({ ok: false, status: 404 }),
+        );
+        global.fetch = fetchSpy;
+        await renderMergifyContext({ org: "o", repo: "r", number: 122 });
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+        await renderMergifyContext({ org: "o", repo: "r", number: 122 });
+        // Second tick: the failure is cached, no extra fetch fired.
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("falls back to Conversation HTML when local DOM has no comments (Files tab)", async () => {
+        // Simulate the Files tab: no .TimelineItem in the local DOM, only
+        // the panel injection target. The Conversation page HTML, fetched
+        // on demand, contains the Mergify-stack comment we need.
+        const stackPayload = {
+            schema_version: 1,
+            stack_id: "x",
+            pulls: [
+                {
+                    number: 11335,
+                    change_id: "i",
+                    head_sha: "h",
+                    base_branch: "main",
+                    dest_branch: "x",
+                    is_current: true,
+                },
+                {
+                    number: 11336,
+                    change_id: "j",
+                    head_sha: "h2",
+                    base_branch: "x",
+                    dest_branch: "x",
+                    is_current: false,
+                },
+            ],
+        };
+        const stackBody =
+            "Stack:\n" +
+            "| 0 | T1 | [#11335](https://x/11335) | 👈 |\n" +
+            "| 1 | T2 | [#11336](https://x/11336) |  |\n" +
+            `<!-- mergify-stack-data: ${JSON.stringify(stackPayload)} -->`;
+        document.body.innerHTML =
+            '<div id="discussion_bucket"></div>' +
+            '<section class="use-sticky-header-module__stickyHeader__abc"></section>';
+        const conversationHtml =
+            "<html><body>" +
+            '<div class="TimelineItem">' +
+            '<div id="issuecomment-9001"></div>' +
+            '<div class="comment-body">Mergify stack</div>' +
+            "</div>" +
+            "</body></html>";
+        const escaped = stackBody
+            .replace(/&/g, "&amp;")
+            .replace(/</g, "&lt;")
+            .replace(/>/g, "&gt;");
+        global.fetch = jest.fn((url) => {
+            if (typeof url !== "string") {
+                return Promise.resolve({
+                    ok: true,
+                    text: () => Promise.resolve(""),
+                });
+            }
+            if (/\/issue_comments\/9001\/edit_form$/.test(url)) {
+                return Promise.resolve({
+                    ok: true,
+                    text: () =>
+                        Promise.resolve(
+                            `<html><body><textarea>${escaped}</textarea></body></html>`,
+                        ),
+                });
+            }
+            if (url.endsWith("/o/r/pull/11335")) {
+                return Promise.resolve({
+                    ok: true,
+                    text: () => Promise.resolve(conversationHtml),
+                });
+            }
+            return Promise.resolve({
+                ok: true,
+                text: () => Promise.resolve(""),
+            });
+        });
+        await renderMergifyContext({ org: "o", repo: "r", number: 11335 });
+        expect(document.querySelector("#mergify-context")).not.toBeNull();
+        expect(
+            document.querySelector('[data-mergify-pr-row="11335"]'),
+        ).not.toBeNull();
+    });
+
+    it("removes a stale panel/nav when bodies become empty", async () => {
+        const stackPayload = {
+            schema_version: 1,
+            stack_id: "x",
+            pulls: [
+                {
+                    number: 122,
+                    change_id: "i1",
+                    head_sha: "h1",
+                    base_branch: "main",
+                    dest_branch: "x",
+                    is_current: true,
+                },
+                {
+                    number: 123,
+                    change_id: "i2",
+                    head_sha: "h2",
+                    base_branch: "x",
+                    dest_branch: "x",
+                    is_current: false,
+                },
+            ],
+        };
+        const stackBody =
+            "Stack:\n" +
+            "| 0 | T1 | [#122](https://x/122) | 👈 |\n" +
+            "| 1 | T2 | [#123](https://x/123) |  |\n" +
+            `<!-- mergify-stack-data: ${JSON.stringify(stackPayload)} -->`;
+        document.body.innerHTML =
+            '<div id="discussion_bucket"></div>' +
+            '<section class="use-sticky-header-module__stickyHeader__abc PullRequestFilesToolbar-module__toolbar__def"></section>' +
+            '<div class="TimelineItem">' +
+            '<div id="issuecomment-1"></div>' +
+            '<div class="comment-body">Mergify stack</div>' +
+            "</div>";
+        const escaped = stackBody
+            .replace(/&/g, "&amp;")
+            .replace(/</g, "&lt;")
+            .replace(/>/g, "&gt;");
+        global.fetch = jest.fn((url) => {
+            if (
+                typeof url === "string" &&
+                /\/issue_comments\/\d+\/edit_form$/.test(url)
+            ) {
+                return Promise.resolve({
+                    ok: true,
+                    text: () =>
+                        Promise.resolve(
+                            `<html><body><textarea>${escaped}</textarea></body></html>`,
+                        ),
+                });
+            }
+            return Promise.resolve({
+                ok: true,
+                text: () => Promise.resolve(""),
+            });
+        });
+        await renderMergifyContext({ org: "o", repo: "r", number: 122 });
+        expect(document.querySelector("#mergify-context")).not.toBeNull();
+        expect(document.querySelector("#mergify-stack-nav")).not.toBeNull();
+        // Now the comments disappear.
+        for (const el of document.querySelectorAll(".TimelineItem")) {
+            el.remove();
+        }
+        await renderMergifyContext({ org: "o", repo: "r", number: 122 });
+        expect(document.querySelector("#mergify-context")).toBeNull();
+        expect(document.querySelector("#mergify-stack-nav")).toBeNull();
+    });
+
     it("resetQueueState removes any existing #mergify-context panel", () => {
         document.body.innerHTML =
             '<div id="discussion_bucket"><div id="mergify-context"></div></div>';
@@ -2369,6 +2564,42 @@ describe("injectStackNav", () => {
             "</section>";
         injectStackNav(null, { org: "o", repo: "r", number: 1 });
         expect(document.querySelector("#mergify-stack-nav")).toBeNull();
+    });
+
+    it("resets toolbar overrides when null even if our nav is already gone", () => {
+        // React may have replaced the sticky element after we tweaked its
+        // inline styles: the nav node is gone but flexWrap and padding-bottom
+        // we set linger. injectStackNav(null, ...) must restore them.
+        document.body.innerHTML =
+            '<section class="use-sticky-header-module__stickyHeader__abc"></section>';
+        const sticky = document.querySelector(
+            '[class*="use-sticky-header-module__stickyHeader"]',
+        );
+        sticky.style.flexWrap = "wrap";
+        sticky.style.setProperty("padding-bottom", "0", "important");
+        injectStackNav(null, { org: "o", repo: "r", number: 1 });
+        expect(sticky.style.flexWrap).toBe("");
+        expect(sticky.style.getPropertyValue("padding-bottom")).toBe("");
+    });
+
+    it("injects a sticky-offset CSS rule and removes it on null", () => {
+        document.body.innerHTML =
+            '<section class="use-sticky-header-module__stickyHeader__abc PullRequestFilesToolbar-module__toolbar__def"></section>';
+        const stack = {
+            schema_version: 1,
+            stack_id: "x",
+            pulls: [pull(1, { is_current: true }), pull(2)],
+        };
+        injectStackNav(stack, { org: "o", repo: "r", number: 1 });
+        const style = document.getElementById("mergify-sticky-offset-fix");
+        expect(style).not.toBeNull();
+        // Rule targets GitHub's lower sticky pane and has !important.
+        expect(style.textContent).toMatch(
+            /\[class\*="DiffComparisonViewer-module__Pane"\]\s*\{\s*top:\s*\d+px\s*!important;\s*\}/,
+        );
+        // Removing the nav removes the style.
+        injectStackNav(null, { org: "o", repo: "r", number: 1 });
+        expect(document.getElementById("mergify-sticky-offset-fix")).toBeNull();
     });
 
     it("no-ops when no sticky target is found", () => {

--- a/src/stacks.js
+++ b/src/stacks.js
@@ -137,9 +137,9 @@ export function parseRevisionMarker(commentBodies, pullNumber) {
     return latest;
 }
 
-export function findMergifyCommentIds() {
+function findMergifyCommentIdsIn(scope) {
     const ids = new Set();
-    const containers = document.querySelectorAll(
+    const containers = scope.querySelectorAll(
         ".TimelineItem, .js-comment-container, .timeline-comment",
     );
     for (const c of containers) {
@@ -152,6 +152,38 @@ export function findMergifyCommentIds() {
         if (m) ids.add(m[1]);
     }
     return [...ids];
+}
+
+export function findMergifyCommentIds() {
+    return findMergifyCommentIdsIn(document);
+}
+
+// On the Files tab, GitHub doesn't render the conversation timeline at all,
+// so the local DOM scan returns nothing. Fall back to fetching the
+// Conversation page's HTML and searching there. Result is cached per-PR
+// with a short TTL so subsequent ticks don't re-fetch the ~500KB page.
+const _remoteCommentIdsCache = new Map();
+
+export async function findMergifyCommentIdsRemote(org, repo, prNumber) {
+    const key = `${org}/${repo}/${prNumber}`;
+    const cached = _remoteCommentIdsCache.get(key);
+    if (cached && Date.now() - cached.timestamp < COMMENTS_CACHE_TTL_MS) {
+        return cached.ids;
+    }
+    try {
+        const r = await fetch(`/${org}/${repo}/pull/${prNumber}`);
+        if (!r.ok) return [];
+        const html = await r.text();
+        const doc = new DOMParser().parseFromString(html, "text/html");
+        const ids = findMergifyCommentIdsIn(doc);
+        if (ids.length > 0) {
+            _remoteCommentIdsCache.set(key, { ids, timestamp: Date.now() });
+        }
+        return ids;
+    } catch (e) {
+        debug("findMergifyCommentIdsRemote failed", e);
+        return [];
+    }
 }
 
 export async function fetchCommentBodyMarkdown(org, repo, commentId) {
@@ -170,8 +202,13 @@ export async function fetchCommentBodyMarkdown(org, repo, commentId) {
     }
 }
 
-export async function fetchCommentBodies(org, repo, _prNumber) {
-    const ids = findMergifyCommentIds();
+export async function fetchCommentBodies(org, repo, prNumber) {
+    let ids = findMergifyCommentIds();
+    if (ids.length === 0) {
+        // The Files tab doesn't render conversation comments — fall back to
+        // the Conversation page HTML to discover Mergify-related comment IDs.
+        ids = await findMergifyCommentIdsRemote(org, repo, prNumber);
+    }
     if (ids.length === 0) return [];
     const bodies = [];
     const queue = ids.slice();
@@ -180,18 +217,24 @@ export async function fetchCommentBodies(org, repo, _prNumber) {
         while (queue.length > 0) {
             const id = queue.shift();
             const cached = _commentBodyCache.get(id);
-            if (
-                cached &&
-                Date.now() - cached.timestamp < COMMENTS_CACHE_TTL_MS
-            ) {
-                bodies.push(cached.body);
-                continue;
+            if (cached) {
+                const age = Date.now() - cached.timestamp;
+                if (cached.body && age < COMMENTS_CACHE_TTL_MS) {
+                    bodies.push(cached.body);
+                    continue;
+                }
+                // Negative cache: a recent failure is remembered for a short
+                // back-off window so we don't refetch on every tryInject tick.
+                if (!cached.body && age < COMMENTS_NEGATIVE_CACHE_TTL_MS) {
+                    continue;
+                }
             }
             const body = await fetchCommentBodyMarkdown(org, repo, id);
-            if (body) {
-                _commentBodyCache.set(id, { body, timestamp: Date.now() });
-                bodies.push(body);
-            }
+            _commentBodyCache.set(id, {
+                body: body || null,
+                timestamp: Date.now(),
+            });
+            if (body) bodies.push(body);
         }
     });
     await Promise.all(workers);
@@ -200,6 +243,7 @@ export async function fetchCommentBodies(org, repo, _prNumber) {
 
 export function clearCommentsCache() {
     _commentBodyCache.clear();
+    _remoteCommentIdsCache.clear();
 }
 
 export async function fetchPrStatus(org, repo, num) {
@@ -212,6 +256,10 @@ export async function fetchPrStatus(org, repo, num) {
     } catch (_e) {
         return "unknown";
     }
+}
+
+function _statusKey(item) {
+    return `${item.org}/${item.repo}/${item.num}/${item.head_sha}`;
 }
 
 export async function gatherPrStatuses(
@@ -235,7 +283,17 @@ export async function gatherPrStatuses(
                 onResolve(item, cached);
                 continue;
             }
-            const status = await fetchPrStatus(item.org, item.repo, item.num);
+            // Dedupe concurrent fetches for the same PR — multiple tryInject
+            // ticks during React reconciliation can otherwise spawn the same
+            // request many times before the first response lands.
+            const key = _statusKey(item);
+            let promise = _inflightStatusFetches.get(key);
+            if (!promise) {
+                promise = fetchPrStatus(item.org, item.repo, item.num);
+                _inflightStatusFetches.set(key, promise);
+                promise.finally(() => _inflightStatusFetches.delete(key));
+            }
+            const status = await promise;
             // Don't cache "unknown" — it usually means a transient fetch
             // failure, and we want the next tick to retry rather than serve
             // gray for the full TTL.
@@ -640,6 +698,11 @@ export function injectContextPanel(panel) {
     target.insertBefore(panel, target.firstChild);
 }
 
+export function removeContextSurfaces(currentPull) {
+    document.querySelector("#mergify-context")?.remove();
+    injectStackNav(null, currentPull);
+}
+
 export async function renderMergifyContext(currentPull) {
     const generation = ++_contextRenderGeneration;
     const bodies = await fetchCommentBodies(
@@ -648,12 +711,18 @@ export async function renderMergifyContext(currentPull) {
         currentPull.number,
     );
     if (generation !== _contextRenderGeneration) return;
-    if (bodies.length === 0) return;
+    if (bodies.length === 0) {
+        removeContextSurfaces(currentPull);
+        return;
+    }
 
     const stackData = parseStackMarker(bodies, currentPull.number);
     const revisionData = parseRevisionMarker(bodies, currentPull.number);
     const panel = buildContextPanel(stackData, revisionData, currentPull);
-    if (!panel) return;
+    if (!panel) {
+        removeContextSurfaces(currentPull);
+        return;
+    }
     injectContextPanel(panel);
     injectStackNav(stackData, currentPull);
 
@@ -806,17 +875,73 @@ export function buildStackNav(stackData, currentPull) {
     return root;
 }
 
+// GitHub's diff view has multiple `position: sticky` elements with their
+// `top` hardcoded to the toolbar's original height (e.g., the file-tree pane
+// at top:60px, and per-file headers that pin while you read a long file).
+// Once we grow the toolbar with our nav row, those elements stick UNDER our
+// nav and disappear. We rewrite their `top` two ways:
+//   - A class-substring CSS rule (cheap, survives React re-renders within
+//     a known class).
+//   - A runtime walk that catches anything else with `top > 0` inside the
+//     diff content area, setting an inline `top` with !important. Originals
+//     are tracked in a WeakMap so we can restore on cleanup.
+const STICKY_OFFSET_STYLE_ID = "mergify-sticky-offset-fix";
+const STICKY_OFFSET_KNOWN_SELECTORS = [
+    '[class*="DiffComparisonViewer-module__Pane"]',
+];
+const STICKY_OFFSET_WALK_SCOPES = [
+    '[class*="DiffComparisonViewer"]',
+    '[class*="PullRequestDiffsList"]',
+];
+const _stickyOffsetPatched = new Set();
+
+function updateStickyOffsetFix(target) {
+    const newTop = Math.max(0, target.offsetHeight - 1);
+    let style = document.getElementById(STICKY_OFFSET_STYLE_ID);
+    if (!style) {
+        style = document.createElement("style");
+        style.id = STICKY_OFFSET_STYLE_ID;
+        document.head.appendChild(style);
+    }
+    style.textContent = `${STICKY_OFFSET_KNOWN_SELECTORS.join(", ")} { top: ${newTop}px !important; }`;
+    // Also patch any other sticky descendants with top > 0 that the CSS
+    // selector doesn't catch (e.g., per-file diff headers when scrolled
+    // into a long file).
+    for (const sel of STICKY_OFFSET_WALK_SCOPES) {
+        for (const root of document.querySelectorAll(sel)) {
+            for (const el of root.querySelectorAll("*")) {
+                const cs = getComputedStyle(el);
+                if (cs.position !== "sticky") continue;
+                const t = Number.parseInt(cs.top, 10);
+                if (!t || t <= 0) continue;
+                el.style.setProperty("top", `${newTop}px`, "important");
+                _stickyOffsetPatched.add(el);
+            }
+        }
+    }
+}
+
+function clearStickyOffsetFix() {
+    document.getElementById(STICKY_OFFSET_STYLE_ID)?.remove();
+    for (const el of _stickyOffsetPatched) {
+        el.style.removeProperty("top");
+    }
+    _stickyOffsetPatched.clear();
+}
+
 export function injectStackNav(stackData, currentPull) {
     const target = findStackNavTarget();
     if (!target) return;
     const existing = document.querySelector("#mergify-stack-nav");
     const fresh = buildStackNav(stackData, currentPull);
     if (!fresh) {
-        if (existing) {
-            existing.remove();
-            target.style.flexWrap = "";
-            target.style.removeProperty("padding-bottom");
-        }
+        // Always reset our toolbar overrides — React may have replaced the
+        // sticky element while our nav node was the only thing left holding
+        // the override identity. Run unconditionally.
+        target.style.flexWrap = "";
+        target.style.removeProperty("padding-bottom");
+        if (existing) existing.remove();
+        clearStickyOffsetFix();
         return;
     }
     // The toolbar is a flex-row. Force flex-wrap so our 100%-width child
@@ -827,11 +952,9 @@ export function injectStackNav(stackData, currentPull) {
     // the bottom edge of the sticky bar.
     target.style.flexWrap = "wrap";
     target.style.setProperty("padding-bottom", "0", "important");
-    if (existing) {
-        existing.replaceWith(fresh);
-        return;
-    }
-    target.appendChild(fresh);
+    if (existing) existing.replaceWith(fresh);
+    else target.appendChild(fresh);
+    updateStickyOffsetFix(target);
 }
 
 export function resetStackState() {


### PR DESCRIPTION
Six fixes against the Mergify Stacks feature:

1. Negative caching in fetchCommentBodies: a 404/5xx from edit_form
   is now remembered for 60s so a deleted comment or a transient
   failure no longer causes a refetch on every tryInject tick.

2. Stale UI removal in renderMergifyContext: the early-return paths
   for "no comment bodies" and "panel is null" now explicitly remove
   any existing #mergify-context and #mergify-stack-nav. Previously
   the panel could linger after the markers disappeared.

3. In-flight dedup for status fetches: gatherPrStatuses now reuses a
   single Promise per (org/repo/num/head_sha) so multiple ticks
   during React reconciliation don't fire duplicate fetchPrStatus
   requests.

4. Toolbar reset on null nav path: injectStackNav now resets
   flex-wrap and removes the padding-bottom override unconditionally,
   not gated on whether our nav node still exists. React can drop
   our node while leaving the inline styles behind.

5. Sticky-offset overlap: GitHub's diff-view file-tree pane uses
   position: sticky; top: 60px hardcoded to the toolbar's original
   height. Our nav grows the toolbar to ~93px, which would otherwise
   hide the pane behind our nav. injectStackNav now writes a small
   <style> rule overriding the pane's top to the toolbar's actual
   current height (with !important to outweigh the class rule).
   The rule is removed when our nav is removed.

6. Files-tab discovery fallback: on the /files tab GitHub doesn't
   render the conversation timeline at all, so the local DOM scan
   for Mergify-related comment IDs always returned empty and the
   panel/nav never showed. fetchCommentBodies now falls back to
   fetching the Conversation page HTML and parsing comment IDs from
   it. Result is cached per-PR with a 5-minute TTL so subsequent
   ticks don't re-fetch the ~500 KB page.

Six new tests cover each fix.