### PR TITLE
chore(extension): drop per-tick debug logs that flood console on diff pages

### DIFF
--- a/src/mergify.js
+++ b/src/mergify.js
@@ -20,7 +20,6 @@ import {
     fetchQueueStateIfNeeded,
     getMergifyConfigurationStatus,
     isMergifyEnabledOnTheRepo,
-    lastKnownQueueState,
     resetQueueState,
     scheduleQueueStatePoll,
     updateMergifyRow,
@@ -96,7 +95,6 @@ async function _tryInject() {
 
     // Fetch queue state before first render (only once per PR page visit)
     await fetchQueueStateIfNeeded();
-    debug("Queue state fetched:", lastKnownQueueState);
 
     // New merge box — the mergebox-partial may be inside discussion-timeline-actions
     // or a separate element in the page (GitHub layout varies)
@@ -139,11 +137,9 @@ async function _tryInject() {
         scheduleQueueStatePoll();
         return;
     }
-    debug("No merge box found");
 }
 
 function tryInject() {
-    debug(`Mergify extension injecting: ${injecting} / ${pendingInjection}`);
     if (injecting) {
         pendingInjection = true;
         return;


### PR DESCRIPTION
The MutationObserver fires on every React DOM mutation, which on the
Files tab can be hundreds per second. Three debug() calls fired on
each tick — "Mergify extension injecting:", "Queue state fetched:",
and "No merge box found" — making the dev-build console unusable.
The remaining debug logs only fire on state changes.