### PR TITLE
feat(extension): preserve current PR tab in stack prev/next nav

### DIFF
--- a/src/__tests__/mergify.test.js
+++ b/src/__tests__/mergify.test.js
@@ -2251,6 +2251,26 @@ describe("buildStackNav", () => {
             el.querySelector('[data-mergify-stack-nav="next-empty"]'),
         ).not.toBeNull();
     });
+
+    it("preserves the current subpath in prev/next links", () => {
+        const stack = stackOf(pull(1), pull(2, { is_current: true }), pull(3));
+        const el = buildStackNav(stack, {
+            org: "o",
+            repo: "r",
+            number: 2,
+            subpath: "changes",
+        });
+        expect(
+            el
+                .querySelector('[data-mergify-stack-nav="prev"]')
+                .getAttribute("href"),
+        ).toBe("/o/r/pull/1/changes");
+        expect(
+            el
+                .querySelector('[data-mergify-stack-nav="next"]')
+                .getAttribute("href"),
+        ).toBe("/o/r/pull/3/changes");
+    });
 });
 
 describe("injectStackNav", () => {

--- a/src/mergify.js
+++ b/src/mergify.js
@@ -504,6 +504,7 @@ function getPullRequestData() {
         org: parts[1],
         repo: parts[2],
         pull: parts[4],
+        subpath: parts[5] || "",
     };
 }
 
@@ -832,6 +833,7 @@ async function _tryInject() {
         org: _data.org,
         repo: _data.repo,
         number: Number.parseInt(_data.pull, 10),
+        subpath: _data.subpath,
     });
 
     const existingRow = document.querySelector("#mergify");
@@ -1704,7 +1706,8 @@ function buildStackNav(stackData, currentPull) {
         const a = document.createElement("a");
         a.setAttribute("data-mergify-stack-nav", direction);
         a.setAttribute("data-mergify-stack-nav-num", String(pull.number));
-        a.href = `/${currentPull.org}/${currentPull.repo}/pull/${pull.number}`;
+        const tail = currentPull.subpath ? `/${currentPull.subpath}` : "";
+        a.href = `/${currentPull.org}/${currentPull.repo}/pull/${pull.number}${tail}`;
         a.title = `Open #${pull.number}: ${pull.title}`;
         a.style.cssText =
             "display:flex;align-items:center;gap:6px;" +


### PR DESCRIPTION
The stack prev/next nav at the top of a PR page used to always link to
the bare PR URL, dropping the user back onto the Conversation tab. Now
the link forwards whatever subpath the user is currently viewing
(`/changes`, `/files`, `/commits`, …) so navigating between PRs in a
stack keeps you on the same tab.

Hash and query are intentionally not preserved — they typically point at
PR-specific content (a diff anchor, a comment) that won't apply to the
target PR.