### PR TITLE
feat(extension): make stack-nav dismiss session-only and drop dead-end arrows

### DIFF
--- a/src/__tests__/mergify.test.js
+++ b/src/__tests__/mergify.test.js
@@ -2445,19 +2445,19 @@ describe("buildStackNav", () => {
         expect(labels.some((t) => t === "2/5")).toBe(true);
     });
 
-    it("mutes prev when at the base of the stack", () => {
+    it("omits the prev side entirely when at the base of the stack", () => {
         const stack = stackOf(pull(1, { is_current: true }), pull(2));
         const el = buildStackNav(stack, ctx(1));
         expect(el.querySelector('[data-mergify-stack-nav="prev"]')).toBeNull();
         expect(
             el.querySelector('[data-mergify-stack-nav="prev-empty"]'),
-        ).not.toBeNull();
+        ).toBeNull();
         expect(
             el.querySelector('[data-mergify-stack-nav="next"]'),
         ).not.toBeNull();
     });
 
-    it("mutes next when at the tip of the stack", () => {
+    it("omits the next side entirely when at the tip of the stack", () => {
         const stack = stackOf(pull(1), pull(2, { is_current: true }));
         const el = buildStackNav(stack, ctx(2));
         expect(
@@ -2466,7 +2466,7 @@ describe("buildStackNav", () => {
         expect(el.querySelector('[data-mergify-stack-nav="next"]')).toBeNull();
         expect(
             el.querySelector('[data-mergify-stack-nav="next-empty"]'),
-        ).not.toBeNull();
+        ).toBeNull();
     });
 
     it("preserves the current subpath in prev/next links", () => {
@@ -2507,22 +2507,27 @@ describe("buildStackNav", () => {
         expect(dot.getAttribute("data-mergify-status")).toBe("open");
     });
 
-    it("renders a close button that hides the pill and sets localStorage", () => {
+    it("renders a close button that hides the pill and sets sessionStorage", () => {
         try {
-            localStorage.removeItem("mergify_browser_extension_stack_nav_hidden");
+            sessionStorage.removeItem(
+                "mergify_browser_extension_stack_nav_hidden",
+            );
         } catch (_) {}
         const stack = stackOf(pull(1, { is_current: true }), pull(2));
-        const el = buildStackNav(stack, ctx(1));
-        document.body.appendChild(el);
-        const close = el.querySelector("[data-mergify-stack-nav-close]");
+        // Go through injectStackNav so the document-level click delegate
+        // (which the close button relies on) is installed.
+        injectStackNav(stack, { org: "o", repo: "r", number: 1 });
+        const close = document.querySelector(
+            "#mergify-stack-nav [data-mergify-stack-nav-close]",
+        );
         expect(close).not.toBeNull();
         close.click();
         expect(document.querySelector("#mergify-stack-nav")).toBeNull();
         expect(
-            localStorage.getItem("mergify_browser_extension_stack_nav_hidden"),
+            sessionStorage.getItem("mergify_browser_extension_stack_nav_hidden"),
         ).toBe("1");
         // Cleanup so other tests aren't affected
-        localStorage.removeItem("mergify_browser_extension_stack_nav_hidden");
+        sessionStorage.removeItem("mergify_browser_extension_stack_nav_hidden");
     });
 });
 
@@ -2603,14 +2608,14 @@ describe("injectStackNav", () => {
         expect(document.querySelector("#mergify-stack-nav")).not.toBeNull();
     });
 
-    it("respects the localStorage hide flag", () => {
+    it("respects the sessionStorage hide flag", () => {
         const stack = {
             schema_version: 1,
             stack_id: "x",
             pulls: [pull(1, { is_current: true }), pull(2)],
         };
         try {
-            localStorage.setItem(
+            sessionStorage.setItem(
                 "mergify_browser_extension_stack_nav_hidden",
                 "1",
             );
@@ -2621,7 +2626,7 @@ describe("injectStackNav", () => {
             injectStackNav(stack, { org: "o", repo: "r", number: 1 });
             expect(document.querySelector("#mergify-stack-nav")).toBeNull();
         } finally {
-            localStorage.removeItem(
+            sessionStorage.removeItem(
                 "mergify_browser_extension_stack_nav_hidden",
             );
         }

--- a/src/stacks.js
+++ b/src/stacks.js
@@ -768,9 +768,14 @@ export async function renderMergifyContext(currentPull) {
 
 export const STACK_NAV_HIDDEN_KEY = "mergify_browser_extension_stack_nav_hidden";
 
+// Session-only dismiss: × hides the pill for the rest of this tab/window.
+// A refresh or a new tab brings it back. Most dismisses are "in my way
+// right now" rather than "never show me again", and a per-session flag
+// avoids the dead-end where the only way to restore is clearing storage
+// in DevTools.
 function isStackNavHidden() {
     try {
-        return localStorage.getItem(STACK_NAV_HIDDEN_KEY) === "1";
+        return sessionStorage.getItem(STACK_NAV_HIDDEN_KEY) === "1";
     } catch (_e) {
         return false;
     }
@@ -778,7 +783,7 @@ function isStackNavHidden() {
 
 function setStackNavHidden() {
     try {
-        localStorage.setItem(STACK_NAV_HIDDEN_KEY, "1");
+        sessionStorage.setItem(STACK_NAV_HIDDEN_KEY, "1");
     } catch (_e) {}
 }
 
@@ -848,16 +853,6 @@ export function buildStackNav(stackData, currentPull) {
         return direction === "prev" ? "←" : "→";
     }
 
-    function renderEmpty(direction) {
-        const muted = document.createElement("span");
-        muted.style.cssText =
-            "color:var(--fgColor-muted, #7d8590);opacity:0.4;" +
-            "min-width:24px;text-align:center;flex-shrink:0;";
-        muted.textContent = buildArrow(direction);
-        muted.setAttribute("data-mergify-stack-nav", `${direction}-empty`);
-        return muted;
-    }
-
     function buildLink(pull, direction) {
         const a = document.createElement("a");
         a.setAttribute("data-mergify-stack-nav", direction);
@@ -895,7 +890,7 @@ export function buildStackNav(stackData, currentPull) {
     }
 
     function renderPrev(pull) {
-        if (!pull) return renderEmpty("prev");
+        if (!pull) return null;
         const a = buildLink(pull, "prev");
         const arrow = document.createElement("span");
         arrow.textContent = buildArrow("prev");
@@ -908,7 +903,7 @@ export function buildStackNav(stackData, currentPull) {
     }
 
     function renderNext(pull) {
-        if (!pull) return renderEmpty("next");
+        if (!pull) return null;
         const a = buildLink(pull, "next");
         const dot = buildDot(pull.number);
         const num = document.createElement("span");
@@ -930,10 +925,7 @@ export function buildStackNav(stackData, currentPull) {
     const close = document.createElement("button");
     close.setAttribute("type", "button");
     close.setAttribute("data-mergify-stack-nav-close", "");
-    close.setAttribute(
-        "title",
-        "Hide. Clear localStorage 'mergify_browser_extension_stack_nav_hidden' to restore.",
-    );
+    close.setAttribute("title", "Hide for this session (refresh to restore)");
     close.textContent = "×";
     close.style.cssText =
         "background:transparent;border:none;cursor:pointer;flex-shrink:0;" +
@@ -946,7 +938,9 @@ export function buildStackNav(stackData, currentPull) {
         close.style.color = "var(--fgColor-muted, #7d8590)";
     };
 
-    root.append(renderPrev(prev), stackLabel, renderNext(next), close);
+    for (const child of [renderPrev(prev), stackLabel, renderNext(next), close]) {
+        if (child) root.append(child);
+    }
     return root;
 }
 


### PR DESCRIPTION
Two small UX wins on the floating stack-nav pill:

- × now writes to sessionStorage instead of localStorage. A page refresh
  or a new tab brings the pill back. The previous behaviour stranded the
  user with no in-product way to restore — it required a DevTools visit
  to clear the key. "× hides for now" matches the intent better than
  "× hides forever".
- When the current PR is at the base or the tip of the stack, omit the
  empty arrow side entirely instead of rendering a muted "←"/"→". The
  pill is narrower and reads cleaner.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Depends-On: #442