### PR TITLE
fix(extension): make stack-nav × hide only until refresh, not session

### DIFF
--- a/src/__tests__/mergify.test.js
+++ b/src/__tests__/mergify.test.js
@@ -29,6 +29,7 @@ const {
     clearCommentsCache,
     buildStackNav,
     injectStackNav,
+    resetStackState,
 } = require("../mergify");
 const { loadFixture, injectFixtureInDOM } = require("./utils");
 
@@ -2507,12 +2508,7 @@ describe("buildStackNav", () => {
         expect(dot.getAttribute("data-mergify-status")).toBe("open");
     });
 
-    it("renders a close button that hides the pill and sets sessionStorage", () => {
-        try {
-            sessionStorage.removeItem(
-                "mergify_browser_extension_stack_nav_hidden",
-            );
-        } catch (_) {}
+    it("close button hides the pill until clearStackNavHidden runs", () => {
         const stack = stackOf(pull(1, { is_current: true }), pull(2));
         // Go through injectStackNav so the document-level click delegate
         // (which the close button relies on) is installed.
@@ -2523,11 +2519,13 @@ describe("buildStackNav", () => {
         expect(close).not.toBeNull();
         close.click();
         expect(document.querySelector("#mergify-stack-nav")).toBeNull();
-        expect(
-            sessionStorage.getItem("mergify_browser_extension_stack_nav_hidden"),
-        ).toBe("1");
-        // Cleanup so other tests aren't affected
-        sessionStorage.removeItem("mergify_browser_extension_stack_nav_hidden");
+        // Re-injecting while hidden is a no-op.
+        injectStackNav(stack, { org: "o", repo: "r", number: 1 });
+        expect(document.querySelector("#mergify-stack-nav")).toBeNull();
+        // resetStackState (URL change / refresh proxy) clears the flag.
+        resetStackState();
+        injectStackNav(stack, { org: "o", repo: "r", number: 1 });
+        expect(document.querySelector("#mergify-stack-nav")).not.toBeNull();
     });
 });
 
@@ -2608,27 +2606,23 @@ describe("injectStackNav", () => {
         expect(document.querySelector("#mergify-stack-nav")).not.toBeNull();
     });
 
-    it("respects the sessionStorage hide flag", () => {
+    it("removes a stale pill if the in-memory hide flag is set", () => {
         const stack = {
             schema_version: 1,
             stack_id: "x",
             pulls: [pull(1, { is_current: true }), pull(2)],
         };
-        try {
-            sessionStorage.setItem(
-                "mergify_browser_extension_stack_nav_hidden",
-                "1",
-            );
-            injectStackNav(stack, { org: "o", repo: "r", number: 1 });
-            expect(document.querySelector("#mergify-stack-nav")).toBeNull();
-            // And if a stale pill is in the DOM, it gets removed.
-            document.body.innerHTML = '<div id="mergify-stack-nav"></div>';
-            injectStackNav(stack, { org: "o", repo: "r", number: 1 });
-            expect(document.querySelector("#mergify-stack-nav")).toBeNull();
-        } finally {
-            sessionStorage.removeItem(
-                "mergify_browser_extension_stack_nav_hidden",
-            );
-        }
+        // Inject + dismiss to set the flag.
+        injectStackNav(stack, { org: "o", repo: "r", number: 1 });
+        document
+            .querySelector("#mergify-stack-nav [data-mergify-stack-nav-close]")
+            .click();
+        expect(document.querySelector("#mergify-stack-nav")).toBeNull();
+        // A stale pill in the DOM (e.g. from a Turbo morph) gets swept.
+        document.body.innerHTML = '<div id="mergify-stack-nav"></div>';
+        injectStackNav(stack, { org: "o", repo: "r", number: 1 });
+        expect(document.querySelector("#mergify-stack-nav")).toBeNull();
+        // Reset to clear the flag for subsequent tests.
+        resetStackState();
     });
 });

--- a/src/stacks.js
+++ b/src/stacks.js
@@ -766,25 +766,22 @@ export async function renderMergifyContext(currentPull) {
     }).catch((e) => debug("status fetch failed:", e));
 }
 
-export const STACK_NAV_HIDDEN_KEY = "mergify_browser_extension_stack_nav_hidden";
+// In-memory dismiss flag: × hides the pill for the current page only. A
+// page refresh or an SPA navigation to another PR brings it back. This
+// matches "× hides this view" intent and avoids the dead-end where the
+// only restore path is clearing storage in DevTools.
+let _stackNavHidden = false;
 
-// Session-only dismiss: × hides the pill for the rest of this tab/window.
-// A refresh or a new tab brings it back. Most dismisses are "in my way
-// right now" rather than "never show me again", and a per-session flag
-// avoids the dead-end where the only way to restore is clearing storage
-// in DevTools.
 function isStackNavHidden() {
-    try {
-        return sessionStorage.getItem(STACK_NAV_HIDDEN_KEY) === "1";
-    } catch (_e) {
-        return false;
-    }
+    return _stackNavHidden;
 }
 
 function setStackNavHidden() {
-    try {
-        sessionStorage.setItem(STACK_NAV_HIDDEN_KEY, "1");
-    } catch (_e) {}
+    _stackNavHidden = true;
+}
+
+export function clearStackNavHidden() {
+    _stackNavHidden = false;
 }
 
 function djb2Hash(str) {
@@ -925,7 +922,7 @@ export function buildStackNav(stackData, currentPull) {
     const close = document.createElement("button");
     close.setAttribute("type", "button");
     close.setAttribute("data-mergify-stack-nav-close", "");
-    close.setAttribute("title", "Hide for this session (refresh to restore)");
+    close.setAttribute("title", "Hide (refresh to restore)");
     close.textContent = "×";
     close.style.cssText =
         "background:transparent;border:none;cursor:pointer;flex-shrink:0;" +
@@ -1019,4 +1016,5 @@ export function resetStackState() {
     const panel = document.querySelector("#mergify-context");
     if (panel) panel.remove();
     document.querySelector("#mergify-stack-nav")?.remove();
+    clearStackNavHidden();
 }


### PR DESCRIPTION
sessionStorage persists across page reloads in the same tab — clicking ×
left users with no in-product way to bring the pill back short of
closing the tab. That's not what "× hides" should mean.

Switch to an in-memory module flag, cleared by resetStackState (which
runs on every URL change and on full page load via the content script
re-bootstrapping). Now: × hides → refresh OR navigate to another PR
brings the pill back. Matches the close-button tooltip "Hide (refresh
to restore)".

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Depends-On: #443