### PR TITLE
feat(extension): replace in-toolbar stack nav with floating, hideable pill

### DIFF
--- a/src/__tests__/mergify.test.js
+++ b/src/__tests__/mergify.test.js
@@ -29,6 +29,7 @@ const {
     clearCommentsCache,
     buildStackNav,
     injectStackNav,
+    resetStackState,
 } = require("../mergify");
 const { loadFixture, injectFixtureInDOM } = require("./utils");
 
@@ -2442,22 +2443,22 @@ describe("buildStackNav", () => {
         const el = buildStackNav(stack, ctx(2));
         // The middle label sits between prev and next, exposing the position.
         const labels = Array.from(el.children).map((c) => c.textContent);
-        expect(labels.some((t) => t === "STACK 2/5")).toBe(true);
+        expect(labels.some((t) => t === "2/5")).toBe(true);
     });
 
-    it("mutes prev when at the base of the stack", () => {
+    it("omits the prev side entirely when at the base of the stack", () => {
         const stack = stackOf(pull(1, { is_current: true }), pull(2));
         const el = buildStackNav(stack, ctx(1));
         expect(el.querySelector('[data-mergify-stack-nav="prev"]')).toBeNull();
         expect(
             el.querySelector('[data-mergify-stack-nav="prev-empty"]'),
-        ).not.toBeNull();
+        ).toBeNull();
         expect(
             el.querySelector('[data-mergify-stack-nav="next"]'),
         ).not.toBeNull();
     });
 
-    it("mutes next when at the tip of the stack", () => {
+    it("omits the next side entirely when at the tip of the stack", () => {
         const stack = stackOf(pull(1), pull(2, { is_current: true }));
         const el = buildStackNav(stack, ctx(2));
         expect(
@@ -2466,7 +2467,28 @@ describe("buildStackNav", () => {
         expect(el.querySelector('[data-mergify-stack-nav="next"]')).toBeNull();
         expect(
             el.querySelector('[data-mergify-stack-nav="next-empty"]'),
-        ).not.toBeNull();
+        ).toBeNull();
+    });
+
+    it("shows the prev PR title when at the tip of the stack", () => {
+        const stack = stackOf(
+            pull(1, { title: "feat(api): land the new thing" }),
+            pull(2, { is_current: true }),
+        );
+        const el = buildStackNav(stack, ctx(2));
+        const prev = el.querySelector('[data-mergify-stack-nav="prev"]');
+        expect(prev.textContent).toContain("feat(api): land the new thing");
+    });
+
+    it("does NOT show the prev PR title when not at the tip", () => {
+        const stack = stackOf(
+            pull(1, { title: "feat(api): land the new thing" }),
+            pull(2, { is_current: true }),
+            pull(3),
+        );
+        const el = buildStackNav(stack, ctx(2));
+        const prev = el.querySelector('[data-mergify-stack-nav="prev"]');
+        expect(prev.textContent).not.toContain("feat(api): land the new thing");
     });
 
     it("preserves the current subpath in prev/next links", () => {
@@ -2488,6 +2510,58 @@ describe("buildStackNav", () => {
                 .getAttribute("href"),
         ).toBe("/o/r/pull/3/changes");
     });
+
+    it("prev link carries a status-dot keyed to the prev PR number", () => {
+        const stack = stackOf(pull(1), pull(2, { is_current: true }), pull(3));
+        const el = buildStackNav(stack, ctx(2));
+        const prev = el.querySelector('[data-mergify-stack-nav="prev"]');
+        const dot = prev.querySelector(
+            '[data-mergify-status-dot][data-mergify-pr-num="1"]',
+        );
+        expect(dot).not.toBeNull();
+        // Status-fetch pipeline paints all non-current pulls — the prev dot
+        // updates via updateStackDotStatus just like the next dot.
+        updateStackDotStatus(el, 1, "merged");
+        expect(dot.getAttribute("data-mergify-status")).toBe("merged");
+    });
+
+    it("next link shows the next PR's title and a status-dot keyed to its number", () => {
+        const stack = stackOf(
+            pull(1),
+            pull(2, { is_current: true }),
+            pull(3, { title: "feat(api): land the new thing" }),
+        );
+        const el = buildStackNav(stack, ctx(2));
+        const next = el.querySelector('[data-mergify-stack-nav="next"]');
+        expect(next.textContent).toContain("feat(api): land the new thing");
+        const dot = next.querySelector(
+            '[data-mergify-status-dot][data-mergify-pr-num="3"]',
+        );
+        expect(dot).not.toBeNull();
+        // updateStackDotStatus should paint the dot
+        updateStackDotStatus(el, 3, "open");
+        expect(dot.getAttribute("data-mergify-status")).toBe("open");
+    });
+
+    it("close button hides the pill until clearStackNavHidden runs", () => {
+        const stack = stackOf(pull(1, { is_current: true }), pull(2));
+        // Go through injectStackNav so the document-level click delegate
+        // (which the close button relies on) is installed.
+        injectStackNav(stack, { org: "o", repo: "r", number: 1 });
+        const close = document.querySelector(
+            "#mergify-stack-nav [data-mergify-stack-nav-close]",
+        );
+        expect(close).not.toBeNull();
+        close.click();
+        expect(document.querySelector("#mergify-stack-nav")).toBeNull();
+        // Re-injecting while hidden is a no-op.
+        injectStackNav(stack, { org: "o", repo: "r", number: 1 });
+        expect(document.querySelector("#mergify-stack-nav")).toBeNull();
+        // resetStackState (URL change / refresh proxy) clears the flag.
+        resetStackState();
+        injectStackNav(stack, { org: "o", repo: "r", number: 1 });
+        expect(document.querySelector("#mergify-stack-nav")).not.toBeNull();
+    });
 });
 
 describe("injectStackNav", () => {
@@ -2507,12 +2581,7 @@ describe("injectStackNav", () => {
         };
     }
 
-    function makeStickyHtml() {
-        return '<section class="use-sticky-header-module__stickyHeader__abc PullRequestFilesToolbar-module__toolbar__def"></section>';
-    }
-
-    it("appends the nav as a child of the sticky toolbar and forces flex-wrap", () => {
-        document.body.innerHTML = makeStickyHtml();
+    it("renders a fixed-position pill anchored to the body", () => {
         const stack = {
             schema_version: 1,
             stack_id: "x",
@@ -2521,32 +2590,11 @@ describe("injectStackNav", () => {
         injectStackNav(stack, { org: "o", repo: "r", number: 1 });
         const nav = document.querySelector("#mergify-stack-nav");
         expect(nav).not.toBeNull();
-        const sticky = document.querySelector(
-            '[class*="use-sticky-header-module__stickyHeader"]',
-        );
-        expect(nav.parentElement).toBe(sticky);
-        expect(sticky.style.flexWrap).toBe("wrap");
-    });
-
-    it("ignores the stickyHeaderActivationThreshold sentinel", () => {
-        // The threshold sentinel is a 1px marker that we must NOT inject into.
-        document.body.innerHTML =
-            '<div class="PullRequestFilesToolbar-module__stickyHeaderActivationThreshold__nWqbQ"></div>' +
-            makeStickyHtml();
-        const stack = {
-            schema_version: 1,
-            stack_id: "x",
-            pulls: [pull(1, { is_current: true }), pull(2)],
-        };
-        injectStackNav(stack, { org: "o", repo: "r", number: 1 });
-        const nav = document.querySelector("#mergify-stack-nav");
-        expect(nav.parentElement.className).toMatch(
-            /use-sticky-header-module__stickyHeader/,
-        );
+        expect(nav.parentElement).toBe(document.body);
+        expect(nav.style.position).toBe("fixed");
     });
 
     it("is idempotent — replaces existing nav when called again", () => {
-        document.body.innerHTML = makeStickyHtml();
         const stack = {
             schema_version: 1,
             stack_id: "x",
@@ -2557,59 +2605,59 @@ describe("injectStackNav", () => {
         expect(document.querySelectorAll("#mergify-stack-nav").length).toBe(1);
     });
 
+    it("preserves the existing pill DOM node when nothing changed", () => {
+        // Hover-induced MutationObserver storms re-call injectStackNav. If we
+        // replaceWith() on every call, an in-flight click lands on a detached
+        // anchor and the click event never reaches our document delegate.
+        // The hash check makes the call a no-op when the content is identical.
+        const stack = {
+            schema_version: 1,
+            stack_id: "x",
+            pulls: [pull(1, { is_current: true }), pull(2)],
+        };
+        injectStackNav(stack, { org: "o", repo: "r", number: 1 });
+        const firstNode = document.querySelector("#mergify-stack-nav");
+        injectStackNav(stack, { org: "o", repo: "r", number: 1 });
+        const secondNode = document.querySelector("#mergify-stack-nav");
+        expect(secondNode).toBe(firstNode);
+    });
+
     it("removes the nav when stackData becomes null", () => {
-        document.body.innerHTML =
-            '<section class="use-sticky-header-module__stickyHeader__abc">' +
-            '<div id="mergify-stack-nav"></div>' +
-            "</section>";
+        document.body.innerHTML = '<div id="mergify-stack-nav"></div>';
         injectStackNav(null, { org: "o", repo: "r", number: 1 });
         expect(document.querySelector("#mergify-stack-nav")).toBeNull();
     });
 
-    it("resets toolbar overrides when null even if our nav is already gone", () => {
-        // React may have replaced the sticky element after we tweaked its
-        // inline styles: the nav node is gone but flexWrap and padding-bottom
-        // we set linger. injectStackNav(null, ...) must restore them.
-        document.body.innerHTML =
-            '<section class="use-sticky-header-module__stickyHeader__abc"></section>';
-        const sticky = document.querySelector(
-            '[class*="use-sticky-header-module__stickyHeader"]',
-        );
-        sticky.style.flexWrap = "wrap";
-        sticky.style.setProperty("padding-bottom", "0", "important");
-        injectStackNav(null, { org: "o", repo: "r", number: 1 });
-        expect(sticky.style.flexWrap).toBe("");
-        expect(sticky.style.getPropertyValue("padding-bottom")).toBe("");
-    });
-
-    it("injects a sticky-offset CSS rule and removes it on null", () => {
-        document.body.innerHTML =
-            '<section class="use-sticky-header-module__stickyHeader__abc PullRequestFilesToolbar-module__toolbar__def"></section>';
+    it("does not require any GitHub anchor to inject", () => {
+        // Empty body — pill still attaches to body since it's viewport-fixed
+        // and doesn't depend on GitHub's DOM. This is the whole point of the
+        // floating design: GitHub layout changes can't break it.
         const stack = {
             schema_version: 1,
             stack_id: "x",
             pulls: [pull(1, { is_current: true }), pull(2)],
         };
         injectStackNav(stack, { org: "o", repo: "r", number: 1 });
-        const style = document.getElementById("mergify-sticky-offset-fix");
-        expect(style).not.toBeNull();
-        // Rule targets GitHub's lower sticky pane and has !important.
-        expect(style.textContent).toMatch(
-            /\[class\*="DiffComparisonViewer-module__Pane"\]\s*\{\s*top:\s*\d+px\s*!important;\s*\}/,
-        );
-        // Removing the nav removes the style.
-        injectStackNav(null, { org: "o", repo: "r", number: 1 });
-        expect(document.getElementById("mergify-sticky-offset-fix")).toBeNull();
+        expect(document.querySelector("#mergify-stack-nav")).not.toBeNull();
     });
 
-    it("no-ops when no sticky target is found", () => {
-        document.body.innerHTML = "<div></div>";
+    it("removes a stale pill if the in-memory hide flag is set", () => {
         const stack = {
             schema_version: 1,
             stack_id: "x",
             pulls: [pull(1, { is_current: true }), pull(2)],
         };
+        // Inject + dismiss to set the flag.
+        injectStackNav(stack, { org: "o", repo: "r", number: 1 });
+        document
+            .querySelector("#mergify-stack-nav [data-mergify-stack-nav-close]")
+            .click();
+        expect(document.querySelector("#mergify-stack-nav")).toBeNull();
+        // A stale pill in the DOM (e.g. from a Turbo morph) gets swept.
+        document.body.innerHTML = '<div id="mergify-stack-nav"></div>';
         injectStackNav(stack, { org: "o", repo: "r", number: 1 });
         expect(document.querySelector("#mergify-stack-nav")).toBeNull();
+        // Reset to clear the flag for subsequent tests.
+        resetStackState();
     });
 });

--- a/src/mergify.js
+++ b/src/mergify.js
@@ -63,6 +63,14 @@ export function resetForNavigation() {
 
 async function _tryInject() {
     if (!isGitHubPullRequestPage()) {
+        // SPA-navigated away from a PR (e.g., back to /pulls). The
+        // floating stack-nav pill is body-fixed and outside Turbo's
+        // tree, so Turbo won't sweep it for us — clean up our own
+        // surfaces. Guarded so MutationObserver re-firing on the new
+        // page doesn't churn cleanup work.
+        if (lastPullRequestUrl !== null) {
+            resetForNavigation();
+        }
         debug("Not a pull request page");
         return;
     }

--- a/src/stacks.js
+++ b/src/stacks.js
@@ -26,10 +26,6 @@ export const CONTEXT_PANEL_TARGETS = [
     ".js-discussion",
 ];
 
-export const STACK_NAV_TARGETS = [
-    '[class*="use-sticky-header-module__stickyHeader"]',
-];
-
 // Module-level state
 export const _commentBodyCache = new Map();
 export const _inflightStatusFetches = new Map();
@@ -167,8 +163,13 @@ const _remoteCommentIdsCache = new Map();
 export async function findMergifyCommentIdsRemote(org, repo, prNumber) {
     const key = `${org}/${repo}/${prNumber}`;
     const cached = _remoteCommentIdsCache.get(key);
-    if (cached && Date.now() - cached.timestamp < COMMENTS_CACHE_TTL_MS) {
-        return cached.ids;
+    if (cached) {
+        const age = Date.now() - cached.timestamp;
+        const ttl =
+            cached.ids.length > 0
+                ? COMMENTS_CACHE_TTL_MS
+                : COMMENTS_NEGATIVE_CACHE_TTL_MS;
+        if (age < ttl) return cached.ids;
     }
     try {
         const r = await fetch(`/${org}/${repo}/pull/${prNumber}`);
@@ -176,9 +177,10 @@ export async function findMergifyCommentIdsRemote(org, repo, prNumber) {
         const html = await r.text();
         const doc = new DOMParser().parseFromString(html, "text/html");
         const ids = findMergifyCommentIdsIn(doc);
-        if (ids.length > 0) {
-            _remoteCommentIdsCache.set(key, { ids, timestamp: Date.now() });
-        }
+        // Cache hits and misses both. Empty result uses a shorter TTL so we
+        // discover comments soon after they appear without re-downloading the
+        // ~500KB Conversation HTML on every tryInject tick.
+        _remoteCommentIdsCache.set(key, { ids, timestamp: Date.now() });
         return ids;
     } catch (e) {
         debug("findMergifyCommentIdsRemote failed", e);
@@ -727,9 +729,6 @@ export async function renderMergifyContext(currentPull) {
     injectStackNav(stackData, currentPull);
 
     if (!stackData) return;
-    const live = document.querySelector("#mergify-context");
-    if (!live) return;
-
     const items = stackData.pulls
         .filter((p) => !p.is_current)
         .map((p) => ({
@@ -744,7 +743,10 @@ export async function renderMergifyContext(currentPull) {
     // outlive a status change the user has now seen with their own eyes.
     const currentStatus = readCurrentPrStatus();
     if (currentStatus) {
-        updateStackDotStatus(live, currentPull.number, currentStatus);
+        const live = document.querySelector("#mergify-context");
+        if (live) {
+            updateStackDotStatus(live, currentPull.number, currentStatus);
+        }
         const currentEntry = stackData.pulls.find(
             (p) => p.number === currentPull.number,
         );
@@ -763,19 +765,37 @@ export async function renderMergifyContext(currentPull) {
 
     gatherPrStatuses(items, _prStatusCache, (item, status) => {
         if (generation !== _contextRenderGeneration) return;
-        const fresh = document.querySelector("#mergify-context");
-        if (!fresh) return;
-        updateStackDotStatus(fresh, item.num, status);
+        const panel = document.querySelector("#mergify-context");
+        if (panel) updateStackDotStatus(panel, item.num, status);
+        const nav = document.querySelector("#mergify-stack-nav");
+        if (nav) updateStackDotStatus(nav, item.num, status);
     }).catch((e) => debug("status fetch failed:", e));
 }
 
-// The `use-sticky-header-module` class is shared across both the Conversation
-// tab's StickyPullRequestHeader and the Files tab's PullRequestFilesToolbar
-// (the actual toolbar, not the 1px stickyHeaderActivationThreshold sentinel).
-export function findStackNavTarget() {
-    return document.querySelector(
-        '[class*="use-sticky-header-module__stickyHeader"]',
-    );
+// In-memory dismiss flag: × hides the pill for the current page only. A
+// page refresh or an SPA navigation to another PR brings it back. This
+// matches "× hides this view" intent and avoids the dead-end where the
+// only restore path is clearing storage in DevTools.
+let _stackNavHidden = false;
+
+function isStackNavHidden() {
+    return _stackNavHidden;
+}
+
+function setStackNavHidden() {
+    _stackNavHidden = true;
+}
+
+export function clearStackNavHidden() {
+    _stackNavHidden = false;
+}
+
+function djb2Hash(str) {
+    let h = 0;
+    for (let i = 0; i < str.length; i++) {
+        h = ((h << 5) - h + str.charCodeAt(i)) | 0;
+    }
+    return String(h);
 }
 
 export function buildStackNav(stackData, currentPull) {
@@ -790,185 +810,242 @@ export function buildStackNav(stackData, currentPull) {
     const next =
         idx < stackData.pulls.length - 1 ? stackData.pulls[idx + 1] : null;
 
+    // Standalone floating pill anchored to the viewport — fully decoupled
+    // from GitHub's layout so toolbar/header redesigns don't break us. Lives
+    // directly under <body>.
     const root = document.createElement("div");
     root.id = "mergify-stack-nav";
-    // flex:1 0 100% + min-width:100% + order:99 force the nav onto its own
-    // row inside the sticky toolbar's flex container (which we set to
-    // flex-wrap:wrap during injection). Symmetric vertical padding (no border)
-    // keeps the row content visually centered.
+    // Hash of the displayed content. Used by injectStackNav to skip
+    // identical re-renders. This matters during hover storms: GitHub's
+    // hover-card popover mutates the DOM, our MutationObserver re-fires
+    // tryInject → renderMergifyContext → injectStackNav. Without the
+    // dedup, we'd `replaceWith` on every hover and detach the anchor mid-
+    // click, eating the click event.
+    root.setAttribute(
+        "data-mergify-hash",
+        djb2Hash(
+            JSON.stringify({
+                cur: currentPull.number,
+                sub: currentPull.subpath || "",
+                org: currentPull.org,
+                repo: currentPull.repo,
+                len: stackData.pulls.length,
+                idx,
+                prev: prev ? `${prev.number}/${prev.title}` : null,
+                next: next ? `${next.number}/${next.title}` : null,
+            }),
+        ),
+    );
     root.style.cssText =
-        "display:grid;grid-template-columns:1fr auto 1fr;gap:12px;" +
-        "align-items:center;padding:6px 16px;font-size:11px;" +
-        "background:var(--bgColor-muted, #161b22);" +
-        "box-shadow:inset 0 1px 0 var(--borderColor-default, #30363d);" +
-        "flex:1 0 100%;min-width:100%;order:99;box-sizing:border-box;";
+        "position:fixed;bottom:16px;right:16px;z-index:50;" +
+        "display:inline-flex;align-items:center;gap:10px;" +
+        "padding:6px 8px 6px 12px;font-size:12px;" +
+        "background:var(--bgColor-default, #0d1117);" +
+        "color:var(--fgColor-default, #f0f6fc);" +
+        "border:1px solid var(--borderColor-default, #30363d);" +
+        "border-radius:999px;box-sizing:border-box;" +
+        "box-shadow:0 8px 24px rgba(0,0,0,0.25);" +
+        "font-variant-numeric:tabular-nums;max-width:560px;";
 
     const stackLabel = document.createElement("span");
     stackLabel.style.cssText =
-        "color:var(--fgColor-muted, #7d8590);" +
-        "text-transform:uppercase;letter-spacing:0.5px;" +
-        "font-size:10px;font-weight:600;text-align:center;" +
-        "font-variant-numeric:tabular-nums;";
-    stackLabel.textContent = `STACK ${idx + 1}/${stackData.pulls.length}`;
+        "color:var(--fgColor-muted, #7d8590);font-weight:600;font-size:11px;flex-shrink:0;";
+    stackLabel.textContent = `${idx + 1}/${stackData.pulls.length}`;
 
-    function renderHalf(pull, direction) {
-        const arrow = direction === "prev" ? "←" : "→";
-        const align = direction === "prev" ? "left" : "right";
-        if (!pull) {
-            const muted = document.createElement("span");
-            muted.style.cssText =
-                `text-align:${align};color:var(--fgColor-muted, #7d8590);` +
-                "white-space:nowrap;overflow:hidden;text-overflow:ellipsis;" +
-                "font-style:italic;";
-            muted.textContent =
-                direction === "prev" ? "base of stack" : "tip of stack";
-            muted.setAttribute("data-mergify-stack-nav", `${direction}-empty`);
-            return muted;
-        }
+    function buildArrow(direction) {
+        return direction === "prev" ? "←" : "→";
+    }
+
+    function buildLink(pull, direction) {
         const a = document.createElement("a");
         a.setAttribute("data-mergify-stack-nav", direction);
         a.setAttribute("data-mergify-stack-nav-num", String(pull.number));
+        // Opt out of GitHub's Turbo Drive — without this, Turbo intercepts
+        // the click, calls preventDefault, then fails to actually navigate
+        // because our anchor isn't in any Turbo frame. The data-turbo
+        // attribute makes Turbo ignore the link so the browser's default
+        // navigation runs.
+        a.setAttribute("data-turbo", "false");
         const tail = currentPull.subpath ? `/${currentPull.subpath}` : "";
         a.href = `/${currentPull.org}/${currentPull.repo}/pull/${pull.number}${tail}`;
         a.title = `Open #${pull.number}: ${pull.title}`;
         a.style.cssText =
-            "display:flex;align-items:center;gap:6px;" +
-            "color:var(--fgColor-accent, #58a6ff);" +
-            "text-decoration:none;white-space:nowrap;overflow:hidden;" +
-            (direction === "prev"
-                ? "justify-content:flex-start;"
-                : "justify-content:flex-end;");
-        a.onmouseenter = () => {
-            a.style.textDecoration = "underline";
-        };
-        a.onmouseleave = () => {
-            a.style.textDecoration = "none";
-        };
-        const arrowEl = document.createElement("span");
-        arrowEl.style.cssText =
-            "color:var(--fgColor-muted, #7d8590);flex-shrink:0;font-size:13px;";
-        arrowEl.textContent = arrow;
+            "display:inline-flex;align-items:center;gap:6px;min-width:0;" +
+            "color:var(--fgColor-accent, #58a6ff);text-decoration:none;";
+        return a;
+    }
+
+    function buildDot(prNumber) {
+        const dot = document.createElement("span");
+        dot.setAttribute("data-mergify-status-dot", "");
+        dot.setAttribute("data-mergify-pr-num", String(prNumber));
+        dot.setAttribute("data-mergify-status", "unknown");
+        dot.style.cssText =
+            "width:8px;height:8px;border-radius:50%;flex-shrink:0;" +
+            "background:var(--fgColor-muted, #7d8590);";
+        return dot;
+    }
+
+    function renderPrev(pull, { withTitle } = {}) {
+        if (!pull) return null;
+        const a = buildLink(pull, "prev");
+        const arrow = document.createElement("span");
+        arrow.textContent = buildArrow("prev");
+        arrow.style.cssText = "flex-shrink:0;";
+        const dot = buildDot(pull.number);
         const num = document.createElement("span");
-        num.style.cssText =
-            "color:var(--fgColor-muted, #7d8590);flex-shrink:0;" +
-            "font-variant-numeric:tabular-nums;";
         num.textContent = `#${pull.number}`;
-        const title = document.createElement("span");
-        title.textContent = pull.title;
-        title.style.cssText =
-            "overflow:hidden;text-overflow:ellipsis;min-width:0;";
-        if (direction === "prev") {
-            a.appendChild(arrowEl);
-            a.appendChild(num);
-            a.appendChild(title);
-        } else {
-            a.appendChild(title);
-            a.appendChild(num);
-            a.appendChild(arrowEl);
+        num.style.cssText = "flex-shrink:0;";
+        a.append(arrow, dot, num);
+        if (withTitle) {
+            const title = document.createElement("span");
+            title.textContent = pull.title;
+            title.style.cssText =
+                "color:var(--fgColor-default, #f0f6fc);" +
+                "max-width:280px;overflow:hidden;text-overflow:ellipsis;" +
+                "white-space:nowrap;min-width:0;";
+            a.append(title);
         }
         return a;
     }
 
-    root.appendChild(renderHalf(prev, "prev"));
-    root.appendChild(stackLabel);
-    root.appendChild(renderHalf(next, "next"));
+    function renderNext(pull) {
+        if (!pull) return null;
+        const a = buildLink(pull, "next");
+        const dot = buildDot(pull.number);
+        const num = document.createElement("span");
+        num.textContent = `#${pull.number}`;
+        num.style.cssText = "flex-shrink:0;";
+        const title = document.createElement("span");
+        title.textContent = pull.title;
+        title.style.cssText =
+            "color:var(--fgColor-default, #f0f6fc);" +
+            "max-width:280px;overflow:hidden;text-overflow:ellipsis;" +
+            "white-space:nowrap;min-width:0;";
+        const arrow = document.createElement("span");
+        arrow.textContent = buildArrow("next");
+        arrow.style.cssText = "flex-shrink:0;";
+        a.append(dot, num, title, arrow);
+        return a;
+    }
+
+    const close = document.createElement("button");
+    close.setAttribute("type", "button");
+    close.setAttribute("data-mergify-stack-nav-close", "");
+    close.setAttribute(
+        "aria-label",
+        "Hide Mergify stack navigation (returns on refresh or PR navigation)",
+    );
+    close.setAttribute("title", "Hide (returns on refresh or PR navigation)");
+    close.textContent = "×";
+    close.style.cssText =
+        "background:transparent;border:none;cursor:pointer;flex-shrink:0;" +
+        "padding:0 4px;color:var(--fgColor-muted, #7d8590);" +
+        "font-size:16px;line-height:1;border-radius:50%;";
+
+    for (const child of [
+        renderPrev(prev, { withTitle: !next }),
+        stackLabel,
+        renderNext(next),
+        close,
+    ]) {
+        if (child) root.append(child);
+    }
     return root;
 }
 
-// GitHub's diff view has multiple `position: sticky` elements with their
-// `top` hardcoded to the toolbar's original height (e.g., the file-tree pane
-// at top:60px, and per-file headers that pin while you read a long file).
-// Once we grow the toolbar with our nav row, those elements stick UNDER our
-// nav and disappear. We rewrite their `top` two ways:
-//   - A class-substring CSS rule (cheap, survives React re-renders within
-//     a known class).
-//   - A runtime walk that catches anything else with `top > 0` inside the
-//     diff content area, setting an inline `top` with !important. Originals
-//     are tracked in a WeakMap so we can restore on cleanup.
-const STICKY_OFFSET_STYLE_ID = "mergify-sticky-offset-fix";
-const STICKY_OFFSET_KNOWN_SELECTORS = [
-    '[class*="DiffComparisonViewer-module__Pane"]',
-];
-const STICKY_OFFSET_WALK_SCOPES = [
-    '[class*="DiffComparisonViewer"]',
-    '[class*="PullRequestDiffsList"]',
-];
-const _stickyOffsetPatched = new Set();
-
-function updateStickyOffsetFix(target) {
-    const newTop = Math.max(0, target.offsetHeight - 1);
-    let style = document.getElementById(STICKY_OFFSET_STYLE_ID);
-    if (!style) {
-        style = document.createElement("style");
-        style.id = STICKY_OFFSET_STYLE_ID;
-        document.head.appendChild(style);
-    }
-    style.textContent = `${STICKY_OFFSET_KNOWN_SELECTORS.join(", ")} { top: ${newTop}px !important; }`;
-    // Also patch any other sticky descendants with top > 0 that the CSS
-    // selector doesn't catch (e.g., per-file diff headers when scrolled
-    // into a long file).
-    for (const sel of STICKY_OFFSET_WALK_SCOPES) {
-        for (const root of document.querySelectorAll(sel)) {
-            for (const el of root.querySelectorAll("*")) {
-                const cs = getComputedStyle(el);
-                if (cs.position !== "sticky") continue;
-                const t = Number.parseInt(cs.top, 10);
-                if (!t || t <= 0) continue;
-                el.style.setProperty("top", `${newTop}px`, "important");
-                _stickyOffsetPatched.add(el);
-            }
-        }
-    }
+// Hover styling lives in a one-time `<style>` rule rather than on each
+// element via .onmouseenter/.onmouseleave: those JS properties don't
+// survive Turbo DOM morphs and the hash dedup in injectStackNav means we
+// might not re-render the pill after a morph to re-attach them. CSS is
+// painted by the browser from the document stylesheet which is unaffected.
+const STACK_NAV_STYLE_ID = "mergify-stack-nav-style";
+function ensureStackNavStyle() {
+    if (document.getElementById(STACK_NAV_STYLE_ID)) return;
+    const style = document.createElement("style");
+    style.id = STACK_NAV_STYLE_ID;
+    style.textContent =
+        "#mergify-stack-nav a[data-mergify-stack-nav]:hover{text-decoration:underline}" +
+        "#mergify-stack-nav [data-mergify-stack-nav-close]:hover{color:var(--fgColor-default,#f0f6fc)}";
+    document.head.appendChild(style);
 }
 
-function clearStickyOffsetFix() {
-    document.getElementById(STICKY_OFFSET_STYLE_ID)?.remove();
-    for (const el of _stickyOffsetPatched) {
-        el.style.removeProperty("top");
-    }
-    _stickyOffsetPatched.clear();
+// Document-level capture-phase click delegation, installed exactly once.
+// We can't bind handlers directly on the pill's elements because Turbo
+// morphs the DOM during navigation/scroll updates and matches our pill by
+// id — preserving the markup but stripping inline event-handler properties
+// (.onclick is a JS property, not part of the morphed HTML). Delegating at
+// document level survives any DOM swap. Capture phase ensures we run before
+// Turbo's own bubble-phase clickBubbled handler can preventDefault without
+// actually navigating.
+let _stackNavDelegated = false;
+function ensureStackNavClickDelegate() {
+    if (_stackNavDelegated) return;
+    _stackNavDelegated = true;
+    document.addEventListener(
+        "click",
+        (e) => {
+            if (
+                e.button !== 0 ||
+                e.metaKey ||
+                e.ctrlKey ||
+                e.shiftKey ||
+                e.altKey
+            ) {
+                return;
+            }
+            const close = e.target?.closest?.(
+                "#mergify-stack-nav [data-mergify-stack-nav-close]",
+            );
+            if (close) {
+                e.preventDefault();
+                e.stopPropagation();
+                setStackNavHidden();
+                document.querySelector("#mergify-stack-nav")?.remove();
+                return;
+            }
+            const link = e.target?.closest?.(
+                "#mergify-stack-nav a[data-mergify-stack-nav]",
+            );
+            if (link?.href) {
+                e.preventDefault();
+                e.stopPropagation();
+                window.location.href = link.href;
+            }
+        },
+        true,
+    );
 }
 
 export function injectStackNav(stackData, currentPull) {
-    const target = findStackNavTarget();
-    if (!target) return;
+    ensureStackNavClickDelegate();
+    ensureStackNavStyle();
     const existing = document.querySelector("#mergify-stack-nav");
-    const fresh = buildStackNav(stackData, currentPull);
-    if (!fresh) {
-        // Always reset our toolbar overrides — React may have replaced the
-        // sticky element while our nav node was the only thing left holding
-        // the override identity. Run unconditionally.
-        target.style.flexWrap = "";
-        target.style.removeProperty("padding-bottom");
+    if (isStackNavHidden()) {
         if (existing) existing.remove();
-        clearStickyOffsetFix();
         return;
     }
-    // The toolbar is a flex-row. Force flex-wrap so our 100%-width child
-    // spills onto a new line below the existing toolbar contents, and stays
-    // inside the same sticky element so it inherits stickiness naturally.
-    // Zero the toolbar's padding-bottom (with !important — GitHub ships an
-    // !important rule for it) so there's no visible gap between our nav and
-    // the bottom edge of the sticky bar.
-    target.style.flexWrap = "wrap";
-    target.style.setProperty("padding-bottom", "0", "important");
-    if (existing) existing.replaceWith(fresh);
-    else target.appendChild(fresh);
-    updateStickyOffsetFix(target);
+    const fresh = buildStackNav(stackData, currentPull);
+    if (!fresh) {
+        if (existing) existing.remove();
+        return;
+    }
+    if (existing) {
+        const oldHash = existing.getAttribute("data-mergify-hash");
+        const newHash = fresh.getAttribute("data-mergify-hash");
+        if (oldHash && newHash && oldHash === newHash) return;
+        existing.replaceWith(fresh);
+    } else {
+        document.body.appendChild(fresh);
+    }
 }
 
 export function resetStackState() {
     _contextRenderGeneration += 1;
     _commentBodyCache.clear();
+    _remoteCommentIdsCache.clear();
     const panel = document.querySelector("#mergify-context");
     if (panel) panel.remove();
-    const nav = document.querySelector("#mergify-stack-nav");
-    if (nav) {
-        const target = findStackNavTarget();
-        nav.remove();
-        if (target) {
-            target.style.flexWrap = "";
-            target.style.removeProperty("padding-bottom");
-        }
-    }
+    document.querySelector("#mergify-stack-nav")?.remove();
+    clearStackNavHidden();
 }


### PR DESCRIPTION
GitHub kept reshaping the Files-tab toolbar (now two native rows + a fixed
60px height), so injecting our nav as a flex-wrap row inside it became
fragile — it pushed Submit-comments to a new row, lived under per-file
diff headers when scrolled, and broke on every layout tweak.

Render the stack nav as a viewport-fixed pill at bottom-right instead:

- Body-direct child, fully decoupled from GitHub's DOM tree.
- Compact: prev '← #N', 'i/n' label, next '● #N <title> →', close '×'.
  Empty arrow sides are omitted at the base/tip of the stack.
- Status dot for the next PR reuses the existing PrStatusCache pipeline.
- Hideable via × with an in-memory dismiss flag; resetStackState clears
  it so the pill comes back after a refresh or navigation. The orchestrator
  also removes the pill on SPA navigation away from a PR (the body-fixed
  pill is outside Turbo's tree, so Turbo won't sweep it for us).
- Anchors get data-turbo='false' so Turbo Drive doesn't intercept clicks
  and fail to navigate. A document-level capture-phase delegate handles
  the click so it survives Turbo morphs that strip inline event handlers.
- buildStackNav writes a content hash; injectStackNav skips replaceWith
  when the hash matches. Without this, GitHub's hovercard popovers fire
  our MutationObserver, we re-inject mid-hover, and an in-flight click
  lands on a detached anchor that no longer bubbles to document.

The whole sticky-offset/walker apparatus is gone — we no longer extend
the toolbar so we don't have to push GitHub's diff-pane sticky elements
out of the way.