### PR TITLE
fix(ci): fail release upload step on any non-2xx GitHub API response

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,21 +45,17 @@ jobs:
           UPLOAD_URL: ${{ github.event.release.upload_url }}
           VERSION: ${{ github.event.release.tag_name }}
         run: |
-          set +e
+          set -euo pipefail
           for name in mergify-firefox-${VERSION}.zip mergify-chrome-${VERSION}.zip mergify-safari-${VERSION}.pkg; do
-            curl -L \
-              --fail \
+            if ! curl -L \
+              --fail-with-body \
               -X POST \
               -H "Accept: application/vnd.github+json" \
               -H "Authorization: Bearer $GITHUB_TOKEN" \
               -H "Content-Type: application/octet-stream" \
               --data-binary "@${name}" \
-              "${UPLOAD_URL%%/assets*}/assets?name=${name}"
-
-            if [ $? = 22 ]; then
-               echo "Upload of $name failed"
-               exit 22
+              "${UPLOAD_URL%%/assets*}/assets?name=${name}"; then
+              echo "Upload of $name failed"
+              exit 1
             fi
-
           done
-          set -e


### PR DESCRIPTION
The "Upload to GitHub release assets" step ran `curl --fail` under
`set +e`, then only treated exit code 22 as a failure
(`if [ $? = 22 ]`). When GitHub returned 422, curl actually exited with
56 ("Failure in receiving network data" - curl aborts the HTTP/2
transfer mid-stream when `--fail` trips), so the `= 22` check never
matched. With errexit disabled the loop finished and the step exited 0,
turning a rejected upload green.

Drop the exit-code guessing: run curl in an `if !` so any non-zero exit
(22, 56, network errors) triggers `exit 1`, and use `--fail-with-body`
so GitHub's error payload (the 422 detail) stays visible in the logs.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>