### PR TITLE
feat(extension): surface engine merge-queue state via the MQ status comment payload

### DIFF
--- a/src/__tests__/mqPayload.test.js
+++ b/src/__tests__/mqPayload.test.js
@@ -1,0 +1,568 @@
+const {
+    parsePayload,
+    PAYLOAD_VERSION,
+    findLatestStatusCommentSync,
+    resolveLatestStatusCommentPayload,
+} = require("../mqPayload");
+
+const validJson = JSON.stringify({
+    version: 1,
+    state: "checking",
+    queue_rule_name: "default",
+    queued_at: "2026-05-29T10:14:02Z",
+    estimated_time_of_merge: "2026-05-29T10:42:18Z",
+    speculative_check_pr: 12345,
+    required_conditions: [
+        { description: "base=main", match: true, subconditions: [] },
+        {
+            description: "any of",
+            match: false,
+            subconditions: [
+                {
+                    description: "check-success=ci/test",
+                    match: false,
+                    subconditions: [],
+                },
+            ],
+        },
+    ],
+});
+
+const wrap = (json) =>
+    `<!---\nDO NOT EDIT\n-*- Mergify Payload -*-\n${json}\n-*- Mergify Payload End -*-\n-->`;
+
+describe("parsePayload", () => {
+    test("returns the parsed payload when marker block is well-formed", () => {
+        const out = parsePayload(wrap(validJson));
+        expect(out).not.toBeNull();
+        expect(out.state).toBe("checking");
+        expect(out.speculative_check_pr).toBe(12345);
+        expect(out.required_conditions[1].subconditions[0].description).toBe(
+            "check-success=ci/test",
+        );
+    });
+
+    test("returns null when marker block is missing", () => {
+        expect(parsePayload("just a regular comment body")).toBeNull();
+    });
+
+    test("returns null when marker block is truncated", () => {
+        const truncated = `<!---\nDO NOT EDIT\n-*- Mergify Payload -*-\n${validJson}\n-->`;
+        expect(parsePayload(truncated)).toBeNull();
+    });
+
+    test("returns null on malformed JSON", () => {
+        expect(parsePayload(wrap("{not valid json"))).toBeNull();
+    });
+
+    test("returns null when version is higher than supported", () => {
+        const future = JSON.stringify({
+            ...JSON.parse(validJson),
+            version: PAYLOAD_VERSION + 1,
+        });
+        expect(parsePayload(wrap(future))).toBeNull();
+    });
+
+    test("returns null when state literal is unknown", () => {
+        const bad = JSON.stringify({
+            ...JSON.parse(validJson),
+            state: "exploded",
+        });
+        expect(parsePayload(wrap(bad))).toBeNull();
+    });
+
+    test("returns null when required_conditions is not an array", () => {
+        const bad = JSON.stringify({
+            ...JSON.parse(validJson),
+            required_conditions: {},
+        });
+        expect(parsePayload(wrap(bad))).toBeNull();
+    });
+
+    test("ignores unknown top-level keys (forward compat)", () => {
+        const future = JSON.stringify({
+            ...JSON.parse(validJson),
+            some_new_key: 42,
+        });
+        const out = parsePayload(wrap(future));
+        expect(out).not.toBeNull();
+        expect(out.state).toBe("checking");
+    });
+
+    test("parses raw markdown source (no HTML wrapping) as engine writes it", () => {
+        // The engine writes the marker block inside an HTML comment in the
+        // markdown source. The raw markdown delivered by edit_form looks like:
+        //   <!---
+        //   DO NOT EDIT
+        //   -*- Mergify Payload -*-
+        //   {...}
+        //   -*- Mergify Payload End -*-
+        //   -->
+        // The leading `<!---` line and trailing `-->` are part of the source,
+        // and the regex anchors on `^DO NOT EDIT` with the `m` flag.
+        const markdown = `<!---\nDO NOT EDIT\n-*- Mergify Payload -*-\n${validJson}\n-*- Mergify Payload End -*-\n-->\n\nMergify is checking your pull request.`;
+        const out = parsePayload(markdown);
+        expect(out).not.toBeNull();
+        expect(out.state).toBe("checking");
+    });
+});
+
+const MARKER_SOURCE = `<!---\nDO NOT EDIT\n-*- Mergify Payload -*-\n{"version":1,"state":"checking","queue_rule_name":null,"queued_at":null,"estimated_time_of_merge":null,"speculative_check_pr":null,"required_conditions":[]}\n-*- Mergify Payload End -*-\n-->`;
+
+// Build a TimelineItem fixture.
+//  - bot:           if true, includes the `a[href="/apps/mergify"]` author link
+//  - inlineSource:  if non-null, embeds a textarea.CommentBox-input with that value
+//  - commentId:     if non-null, wraps the timeline item in an issuecomment-<id> div
+function buildTimelineItem({ bot, inlineSource, commentId } = {}) {
+    const item = document.createElement("div");
+    item.className = "TimelineItem";
+    if (bot) {
+        const author = document.createElement("a");
+        author.setAttribute("href", "/apps/mergify");
+        item.appendChild(author);
+    }
+    const commentBody = document.createElement("div");
+    commentBody.className = "comment-body";
+    item.appendChild(commentBody);
+    if (inlineSource != null) {
+        const ta = document.createElement("textarea");
+        ta.className = "CommentBox-input";
+        // <textarea>.value is the live property; we set it directly so the
+        // resolver picks it up.
+        ta.value = inlineSource;
+        item.appendChild(ta);
+    }
+    if (commentId != null) {
+        const wrapper = document.createElement("div");
+        wrapper.id = `issuecomment-${commentId}`;
+        wrapper.appendChild(item);
+        return wrapper;
+    }
+    return item;
+}
+
+describe("findLatestStatusCommentSync", () => {
+    beforeEach(() => {
+        document.body.innerHTML = "";
+    });
+
+    test("returns payload synchronously when inline textarea has the marker", () => {
+        document.body.appendChild(
+            buildTimelineItem({ bot: true, inlineSource: MARKER_SOURCE }),
+        );
+        const result = findLatestStatusCommentSync();
+        expect(result).not.toBeNull();
+        expect(result.payload).not.toBeNull();
+        expect(result.payload.state).toBe("checking");
+    });
+
+    test("returns payload=null when Mergify comment exists but has no inline textarea", () => {
+        document.body.appendChild(
+            buildTimelineItem({ bot: true, commentId: "12345" }),
+        );
+        const result = findLatestStatusCommentSync();
+        expect(result).not.toBeNull();
+        expect(result.payload).toBeNull();
+        expect(result.commentId).toBe("12345");
+    });
+
+    test("returns null when no Mergify-authored TimelineItem exists", () => {
+        document.body.appendChild(
+            buildTimelineItem({ bot: false, inlineSource: MARKER_SOURCE }),
+        );
+        expect(findLatestStatusCommentSync()).toBeNull();
+    });
+
+    test("picks the newest in DOM order when multiple Mergify comments exist", () => {
+        const firstSource = `<!---\nDO NOT EDIT\n-*- Mergify Payload -*-\n{"version":1,"state":"waiting","queue_rule_name":null,"queued_at":null,"estimated_time_of_merge":null,"speculative_check_pr":null,"required_conditions":[]}\n-*- Mergify Payload End -*-\n-->`;
+        document.body.appendChild(
+            buildTimelineItem({ bot: true, inlineSource: firstSource }),
+        );
+        document.body.appendChild(
+            buildTimelineItem({ bot: true, inlineSource: MARKER_SOURCE }),
+        );
+        const result = findLatestStatusCommentSync();
+        expect(result.payload.state).toBe("checking");
+    });
+
+    test("skips later Mergify-authored events that have no marker and picks the latest status comment", () => {
+        // Real PRs have many Mergify-authored TimelineItems that are events
+        // (labels added, reviewers requested, queue breadcrumbs) AFTER the
+        // status comment in DOM order. The status comment is the only one
+        // with the payload marker; the resolver must skip the events and
+        // pick the latest comment WITH a marker.
+        document.body.appendChild(
+            buildTimelineItem({ bot: true, inlineSource: MARKER_SOURCE }),
+        );
+        // Two subsequent Mergify events without textareas or commentIds —
+        // these are not status comments.
+        document.body.appendChild(buildTimelineItem({ bot: true }));
+        document.body.appendChild(buildTimelineItem({ bot: true }));
+        const result = findLatestStatusCommentSync();
+        expect(result).not.toBeNull();
+        expect(result.payload).not.toBeNull();
+        expect(result.payload.state).toBe("checking");
+    });
+
+    test("falls back to the latest commentId-bearing candidate when no inline marker is present", () => {
+        // None of the candidates have a hydrated textarea with the marker,
+        // but two are issuecomment-hosted. The resolver should return the
+        // latest commentId for the fetch fallback.
+        document.body.appendChild(
+            buildTimelineItem({ bot: true, commentId: "100" }),
+        );
+        document.body.appendChild(buildTimelineItem({ bot: true })); // event
+        document.body.appendChild(
+            buildTimelineItem({ bot: true, commentId: "200" }),
+        );
+        document.body.appendChild(buildTimelineItem({ bot: true })); // event
+        const result = findLatestStatusCommentSync();
+        expect(result).not.toBeNull();
+        expect(result.payload).toBeNull();
+        expect(result.commentId).toBe("200");
+    });
+});
+
+describe("resolveLatestStatusCommentPayload", () => {
+    beforeEach(() => {
+        document.body.innerHTML = "";
+        window.history.replaceState({}, "", "/acme/widget/pull/42");
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    test("returns null when no Mergify comment exists (no fetch)", async () => {
+        global.fetch = jest.fn();
+        const result = await resolveLatestStatusCommentPayload();
+        expect(result).toBeNull();
+        expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    test("returns inline payload without fetching when textarea has marker", async () => {
+        global.fetch = jest.fn();
+        document.body.appendChild(
+            buildTimelineItem({ bot: true, inlineSource: MARKER_SOURCE }),
+        );
+        const result = await resolveLatestStatusCommentPayload();
+        expect(result.payload).not.toBeNull();
+        expect(result.payload.state).toBe("checking");
+        expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    test("falls back to edit_form fetch when inline textarea is absent", async () => {
+        document.body.appendChild(
+            buildTimelineItem({ bot: true, commentId: "9999" }),
+        );
+        const editFormHtml = `<form><textarea name="comment[body]">${MARKER_SOURCE}</textarea></form>`;
+        global.fetch = jest.fn(() =>
+            Promise.resolve({
+                ok: true,
+                text: () => Promise.resolve(editFormHtml),
+            }),
+        );
+        const result = await resolveLatestStatusCommentPayload();
+        expect(global.fetch).toHaveBeenCalledWith(
+            "/acme/widget/issue_comments/9999/edit_form",
+        );
+        expect(result.payload).not.toBeNull();
+        expect(result.payload.state).toBe("checking");
+    });
+
+    test("returns null payload when fetch fails", async () => {
+        document.body.appendChild(
+            buildTimelineItem({ bot: true, commentId: "9999" }),
+        );
+        global.fetch = jest.fn(() =>
+            Promise.resolve({ ok: false, text: () => Promise.resolve("") }),
+        );
+        const result = await resolveLatestStatusCommentPayload();
+        expect(result.payload).toBeNull();
+        expect(result.commentId).toBe("9999");
+    });
+});
+
+const { attach, detach, getCurrent } = require("../mqPayload");
+
+const VALID_PAYLOAD = {
+    version: 1,
+    state: "checking",
+    queue_rule_name: "default",
+    queued_at: "2026-05-29T10:14:02Z",
+    estimated_time_of_merge: "2026-05-29T10:42:18Z",
+    speculative_check_pr: 12345,
+    required_conditions: [],
+};
+
+function markerFor(payload) {
+    return `<!---\nDO NOT EDIT\n-*- Mergify Payload -*-\n${JSON.stringify(payload)}\n-*- Mergify Payload End -*-\n-->`;
+}
+
+function appendInlineComment(payload) {
+    const item = buildTimelineItem({
+        bot: true,
+        inlineSource: markerFor(payload),
+    });
+    document.body.appendChild(item);
+    return item.querySelector("textarea.CommentBox-input");
+}
+
+describe("attach/detach — payload path", () => {
+    beforeEach(() => {
+        document.body.innerHTML = "";
+        window.history.replaceState({}, "", "/acme/widget/pull/42");
+        detach();
+        jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+        detach();
+        jest.useRealTimers();
+    });
+
+    test("fires callback once with payload state when inline textarea is present at attach time", () => {
+        appendInlineComment(VALID_PAYLOAD);
+        const cb = jest.fn();
+        attach(cb);
+        expect(cb).toHaveBeenCalledTimes(1);
+        expect(cb).toHaveBeenCalledWith({
+            source: "payload",
+            payload: expect.objectContaining({ state: "checking" }),
+        });
+        expect(getCurrent()).toEqual({
+            source: "payload",
+            payload: expect.any(Object),
+        });
+    });
+
+    test("re-fires callback when the inline textarea value changes (next periodic poll)", async () => {
+        const ta = appendInlineComment(VALID_PAYLOAD);
+        const cb = jest.fn();
+        attach(cb);
+        cb.mockClear();
+
+        // Engine updates the textarea's `.value`. NOTE: a textarea `.value`
+        // assignment does NOT trigger MutationObserver (MO watches DOM tree
+        // mutations, not property writes), so freshness here relies on the
+        // periodic poll. Advance the clock by QUEUE_POLL_INTERVAL.
+        ta.value = markerFor({ ...VALID_PAYLOAD, state: "frozen" });
+        await jest.advanceTimersByTimeAsync(15_000);
+        // Allow microtasks for _resolveAndEmit's await to settle.
+        for (let i = 0; i < 5; i++) await Promise.resolve();
+        expect(cb).toHaveBeenCalledTimes(1);
+        expect(cb.mock.calls[0][0].payload.state).toBe("frozen");
+    });
+
+    test("does not re-fire when the payload is unchanged", async () => {
+        appendInlineComment(VALID_PAYLOAD);
+        const cb = jest.fn();
+        attach(cb);
+        cb.mockClear();
+
+        await jest.advanceTimersByTimeAsync(15_000);
+        for (let i = 0; i < 5; i++) await Promise.resolve();
+        expect(cb).not.toHaveBeenCalled();
+    });
+
+    test("regression: timeline mutations do NOT trigger edit_form refetch once in payload mode", async () => {
+        // The mqPayload fetched edit_form on every page mutation, which on
+        // mutation-heavy PR pages hammered GitHub. Once the payload is
+        // resolved, the periodic poll owns freshness.
+        appendInlineComment(VALID_PAYLOAD);
+        // Spy on fetch so we can count calls.
+        const fetchSpy = jest.fn(() =>
+            Promise.resolve({
+                ok: false,
+                text: () => Promise.resolve(""),
+            }),
+        );
+        global.fetch = fetchSpy;
+        const cb = jest.fn();
+        attach(cb);
+        cb.mockClear();
+        fetchSpy.mockClear();
+
+        // Simulate a burst of unrelated DOM mutations (GitHub re-renders heavily).
+        for (let i = 0; i < 20; i++) {
+            const noise = document.createElement("div");
+            noise.textContent = `noise-${i}`;
+            document.body.appendChild(noise);
+        }
+        // Let the timeline observer's debounce (800ms) elapse plus extra.
+        await jest.advanceTimersByTimeAsync(2_000);
+        for (let i = 0; i < 5; i++) await Promise.resolve();
+
+        expect(fetchSpy).not.toHaveBeenCalled();
+        expect(cb).not.toHaveBeenCalled();
+    });
+
+    test("detach disconnects observers and timers — subsequent changes do not fire", async () => {
+        const ta = appendInlineComment(VALID_PAYLOAD);
+        const cb = jest.fn();
+        attach(cb);
+        cb.mockClear();
+        detach();
+
+        ta.value = markerFor({ ...VALID_PAYLOAD, state: "frozen" });
+        await jest.advanceTimersByTimeAsync(30_000);
+        for (let i = 0; i < 5; i++) await Promise.resolve();
+        expect(cb).not.toHaveBeenCalled();
+        expect(getCurrent()).toBeNull();
+    });
+});
+
+describe("attach/detach — fallback + upgrade", () => {
+    beforeEach(() => {
+        document.body.innerHTML = "";
+        window.history.replaceState({}, "", "/acme/widget/pull/42");
+        detach();
+        jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+        detach();
+        jest.useRealTimers();
+        jest.restoreAllMocks();
+    });
+
+    function mockChecksFetch(queued) {
+        const checksHtml = `<a href="?check_run_id=999"><span>Mergify Merge Queue</span></a>`;
+        const runHtml = queued ? "Queued for merge" : "Some other state";
+        global.fetch = jest.fn((url) => {
+            const u = String(url);
+            if (u.includes("/checks")) {
+                return Promise.resolve({
+                    ok: true,
+                    text: () => Promise.resolve(checksHtml),
+                });
+            }
+            if (u.includes("/runs/")) {
+                return Promise.resolve({
+                    ok: true,
+                    text: () => Promise.resolve(runHtml),
+                });
+            }
+            // For any other URL (including edit_form), return not-ok so the
+            // payload resolver returns null and we stay in fallback mode.
+            return Promise.resolve({
+                ok: false,
+                text: () => Promise.resolve(""),
+            });
+        });
+    }
+
+    // Flush enough microtask ticks for the initial fallback poll's awaited
+    // fetches to resolve. We can't use runAllTimersAsync because the fallback
+    // recursively schedules itself every QUEUE_POLL_INTERVAL.
+    async function flushFallbackPoll() {
+        for (let i = 0; i < 10; i++) await Promise.resolve();
+    }
+
+    test("emits fallback state when no payload comment is in DOM", async () => {
+        mockChecksFetch(true);
+        const cb = jest.fn();
+        attach(cb);
+        await flushFallbackPoll();
+        expect(cb).toHaveBeenCalledWith({ source: "fallback", queued: true });
+    });
+
+    test("upgrades to payload state when a status comment with inline textarea is added later", async () => {
+        mockChecksFetch(false);
+        const cb = jest.fn();
+        attach(cb);
+        await flushFallbackPoll();
+        cb.mockClear();
+
+        // Engine posts the MQ status comment with an inline (materialized)
+        // edit-form textarea containing the payload marker.
+        appendInlineComment(VALID_PAYLOAD);
+
+        // Timeline observer debounces by TIMELINE_OBSERVER_DEBOUNCE_MS (800ms);
+        // advance past it and let microtasks settle.
+        await jest.advanceTimersByTimeAsync(900);
+        for (let i = 0; i < 10; i++) await Promise.resolve();
+        expect(cb).toHaveBeenCalledTimes(1);
+        expect(cb).toHaveBeenCalledWith({
+            source: "payload",
+            payload: expect.objectContaining({ state: "checking" }),
+        });
+    });
+
+    test("regression: a scheduled fallback poll cannot downgrade after upgrade", async () => {
+        mockChecksFetch(false);
+        const cb = jest.fn();
+        attach(cb);
+        await flushFallbackPoll(); // initial poll resolves: emits fallback
+        cb.mockClear();
+
+        // Advance to just before the next scheduled fallback poll would fire.
+        await jest.advanceTimersByTimeAsync(14_000);
+
+        // Upgrade happens (inline textarea materialized with payload).
+        appendInlineComment(VALID_PAYLOAD);
+        // Timeline observer debounces by TIMELINE_OBSERVER_DEBOUNCE_MS (800ms).
+        await jest.advanceTimersByTimeAsync(900);
+        for (let i = 0; i < 10; i++) await Promise.resolve();
+
+        // Now flush past the original scheduled fallback poll's firing time
+        // plus several more polls.
+        await jest.advanceTimersByTimeAsync(60_000);
+        await flushFallbackPoll();
+        await flushFallbackPoll();
+
+        // No fallback emit should appear after the payload emit.
+        const calls = cb.mock.calls.map(([state]) => state.source);
+        const payloadIdx = calls.lastIndexOf("payload");
+        expect(payloadIdx).toBeGreaterThanOrEqual(0);
+        expect(calls.slice(payloadIdx).every((s) => s === "payload")).toBe(
+            true,
+        );
+    });
+
+    test("does not emit stale fallback state after upgrade has occurred", async () => {
+        // Make the initial fallback fetch slow so it's still in flight when
+        // the upgrade happens.
+        let resolveFetch;
+        const fetchGate = new Promise((resolve) => {
+            resolveFetch = resolve;
+        });
+        global.fetch = jest.fn((url) => {
+            const u = String(url);
+            if (u.includes("/checks") || u.includes("/runs/")) {
+                return fetchGate.then(() => ({
+                    ok: true,
+                    text: () =>
+                        Promise.resolve(
+                            `<a href="?check_run_id=999"><span>Mergify Merge Queue</span></a>`,
+                        ),
+                }));
+            }
+            return Promise.resolve({
+                ok: false,
+                text: () => Promise.resolve(""),
+            });
+        });
+
+        const cb = jest.fn();
+        attach(cb);
+
+        // Upgrade happens before the fallback fetch resolves.
+        appendInlineComment(VALID_PAYLOAD);
+        // Timeline observer debounces by TIMELINE_OBSERVER_DEBOUNCE_MS (800ms).
+        await jest.advanceTimersByTimeAsync(900);
+        for (let i = 0; i < 10; i++) await Promise.resolve();
+
+        // Now let the in-flight fetch resolve.
+        resolveFetch();
+        for (let i = 0; i < 10; i++) await Promise.resolve();
+
+        // There must be a payload emit and NO fallback emit AFTER it.
+        const calls = cb.mock.calls.map(([state]) => state.source);
+        const payloadIdx = calls.lastIndexOf("payload");
+        expect(payloadIdx).toBeGreaterThanOrEqual(0);
+        expect(calls.slice(payloadIdx).every((s) => s === "payload")).toBe(
+            true,
+        );
+    });
+});

--- a/src/__tests__/queue.test.js
+++ b/src/__tests__/queue.test.js
@@ -1,0 +1,497 @@
+const { formatEta } = require("../queue");
+
+const NOW = new Date("2026-05-29T10:35:00Z").getTime();
+
+describe("formatEta", () => {
+    test("returns ~Nm for deltas >= 60s", () => {
+        const eta = new Date(NOW + 7 * 60 * 1000).toISOString();
+        expect(formatEta(eta, NOW)).toBe("~7m");
+    });
+
+    test("rounds minute values", () => {
+        const eta = new Date(NOW + 90 * 1000).toISOString();
+        expect(formatEta(eta, NOW)).toBe("~2m");
+    });
+
+    test("returns ~Ns for deltas in (5s, 60s)", () => {
+        const eta = new Date(NOW + 40 * 1000).toISOString();
+        expect(formatEta(eta, NOW)).toBe("~40s");
+    });
+
+    test('returns "any moment" for deltas in (0, 5s]', () => {
+        const eta = new Date(NOW + 3 * 1000).toISOString();
+        expect(formatEta(eta, NOW)).toBe("any moment");
+    });
+
+    test('returns "overdue by Nm" for negative deltas', () => {
+        const eta = new Date(NOW - 2 * 60 * 1000).toISOString();
+        expect(formatEta(eta, NOW)).toBe("overdue by 2m");
+    });
+
+    test("returns empty string when eta is null", () => {
+        expect(formatEta(null, NOW)).toBe("");
+    });
+
+    test("returns empty string when eta is invalid", () => {
+        expect(formatEta("not a date", NOW)).toBe("");
+    });
+});
+
+const { formatDurationMinutes } = require("../queue");
+
+describe("formatDurationMinutes", () => {
+    test.each([
+        [0, "0m"],
+        [42, "42m"],
+        [59, "59m"],
+        [60, "1h"],
+        [61, "1h 1m"],
+        [822, "13h 42m"], // the case the user hit on PR #522
+        [1439, "23h 59m"],
+        [1440, "1d"],
+        [1500, "1d 1h"],
+        [2880, "2d"],
+        [-5, "0m"], // clamps negatives
+    ])("formats %i minutes as %s", (mins, expected) => {
+        expect(formatDurationMinutes(mins)).toBe(expected);
+    });
+
+    test("rounds fractional minutes", () => {
+        expect(formatDurationMinutes(0.4)).toBe("0m");
+        expect(formatDurationMinutes(0.5)).toBe("1m");
+        expect(formatDurationMinutes(59.7)).toBe("1h");
+    });
+});
+
+const {
+    renderConditionsBlock,
+    buildMergifyRow,
+    MERGE_BOX_ROW_ATTR,
+} = require("../queue");
+
+function leaf(description, match) {
+    return { description, match, subconditions: [] };
+}
+function group(description, match, subconditions) {
+    return { description, match, subconditions };
+}
+
+describe("renderConditionsBlock", () => {
+    test("returns null for empty array", () => {
+        expect(renderConditionsBlock([])).toBeNull();
+    });
+
+    test("shows only unmet leaves; met ones are omitted from the rendered list", () => {
+        const block = renderConditionsBlock([
+            leaf("base=main", true),
+            leaf("approved-reviews-by≥1", true),
+            leaf("check-success=ci/test", false),
+        ]);
+        expect(block.querySelector("h4").textContent).toContain(
+            "Blocking the merge",
+        );
+        const rows = block.querySelectorAll("[data-mergify-condition]");
+        expect(rows).toHaveLength(1);
+        expect(rows[0].textContent).toContain("check-success=ci/test");
+        expect(rows[0].querySelector(".pending")).not.toBeNull();
+    });
+
+    test("when every condition is met, the heading shows an 'all met' marker and no rows are rendered", () => {
+        const block = renderConditionsBlock([
+            leaf("base=main", true),
+            leaf("approved-reviews-by≥1", true),
+        ]);
+        expect(block.querySelector("h4").textContent).toContain(
+            "All required conditions met",
+        );
+        expect(block.querySelectorAll("[data-mergify-condition]")).toHaveLength(
+            0,
+        );
+    });
+
+    test("heading shows the blocker count when multiple things are blocking", () => {
+        const block = renderConditionsBlock([
+            leaf("ci/test", false),
+            leaf("ci/lint", false),
+            leaf("base=main", true),
+        ]);
+        expect(block.querySelector("h4").textContent).toContain("(2)");
+        expect(block.querySelectorAll("[data-mergify-condition]")).toHaveLength(
+            2,
+        );
+    });
+
+    test("met groups are skipped entirely; unmet 'all of' groups flatten transparently", () => {
+        // The matching "all of" group should not produce any row; the
+        // non-matching "all of" group at the second slot flattens its unmet
+        // children directly without a wrapper label.
+        const block = renderConditionsBlock([
+            group("all of", true, [
+                leaf("base=main", true),
+                leaf("repo=acme", true),
+            ]),
+            group("all of", false, [
+                leaf("check-success=ci/test", false),
+                leaf("check-success=ci/lint", true),
+            ]),
+        ]);
+        const rows = block.querySelectorAll("[data-mergify-condition]");
+        expect(rows).toHaveLength(1);
+        expect(rows[0].textContent).toContain("check-success=ci/test");
+    });
+
+    test("unmet 'any of' groups render inline so the disjunction is visible", () => {
+        const block = renderConditionsBlock([
+            group("any of", false, [
+                leaf("label=hotfix", false),
+                leaf("urgency=high", false),
+            ]),
+        ]);
+        const rows = block.querySelectorAll("[data-mergify-condition]");
+        expect(rows).toHaveLength(1);
+        const text = rows[0].textContent;
+        expect(text).toContain("any of");
+        expect(text).toContain("label=hotfix");
+        expect(text).toContain("urgency=high");
+    });
+
+    test("met groups don't contribute rows; unmet leaves at top level still appear", () => {
+        const block = renderConditionsBlock([
+            group("all of", true, [leaf("a", true), leaf("b", true)]),
+            leaf("c", false),
+        ]);
+        const rows = block.querySelectorAll("[data-mergify-condition]");
+        expect(rows).toHaveLength(1);
+        expect(rows[0].textContent).toContain("c");
+    });
+});
+
+const { buildRichRow } = require("../queue");
+
+function payload(overrides = {}) {
+    return {
+        version: 1,
+        state: "checking",
+        queue_rule_name: "default",
+        queued_at: "2026-05-29T10:20:00Z",
+        estimated_time_of_merge: "2026-05-29T10:42:00Z",
+        speculative_check_pr: 12345,
+        required_conditions: [
+            { description: "base=main", match: true, subconditions: [] },
+        ],
+        ...overrides,
+    };
+}
+
+describe("buildRichRow", () => {
+    beforeEach(() => {
+        // jsdom doesn't allow replacing window.location; use replaceState to
+        // change pathname so getPullRequestData() returns the expected org/repo.
+        window.history.replaceState({}, "", "/acme/widget/pull/42");
+    });
+
+    test("renders checking state with pill, ETA, draft-PR link, and conditions block", () => {
+        const row = buildRichRow(payload({ state: "checking" }));
+        expect(row.dataset.mergifyShape).toBe("rich");
+        const pill = row.querySelector("[data-mergify-state-pill]");
+        expect(pill.textContent).toContain("Checking");
+        expect(row.querySelector("[data-mergify-eta]")).not.toBeNull();
+        const draft = row.querySelector("[data-mergify-spec-pr]");
+        expect(draft.getAttribute("href")).toBe("/acme/widget/pull/12345");
+        expect(row.querySelector("[data-mergify-conditions]")).not.toBeNull();
+    });
+
+    test("waiting state hides conditions block and shows grey pill", () => {
+        const row = buildRichRow(
+            payload({ state: "waiting", required_conditions: [] }),
+        );
+        expect(
+            row.querySelector("[data-mergify-state-pill]").textContent,
+        ).toContain("Waiting");
+        expect(row.querySelector("[data-mergify-conditions]")).toBeNull();
+    });
+
+    test("frozen state shows amber pill and surfaces draft-PR link", () => {
+        const row = buildRichRow(payload({ state: "frozen" }));
+        const pill = row.querySelector("[data-mergify-state-pill]");
+        expect(pill.textContent).toContain("Frozen");
+        expect(pill.getAttribute("data-state")).toBe("frozen");
+        expect(row.querySelector("[data-mergify-spec-pr]")).not.toBeNull();
+    });
+
+    test("bisecting state shows red pill and surfaces draft-PR link", () => {
+        const row = buildRichRow(payload({ state: "bisecting" }));
+        const pill = row.querySelector("[data-mergify-state-pill]");
+        expect(pill.textContent).toContain("Bisecting");
+        expect(pill.getAttribute("data-state")).toBe("bisecting");
+        expect(row.querySelector("[data-mergify-spec-pr]")).not.toBeNull();
+    });
+
+    test("merged state hides buttons and shows easter-egg message", () => {
+        const row = buildRichRow(
+            payload({
+                state: "merged",
+                required_conditions: [],
+                speculative_check_pr: null,
+            }),
+        );
+        expect(row.querySelector("[data-mergify-queue-btn]")).toBeNull();
+        expect(row.querySelector("[data-mergify-merged-msg]")).not.toBeNull();
+    });
+
+    test("dequeued state shows red pill and add-to-queue button", () => {
+        const row = buildRichRow(
+            payload({
+                state: "dequeued",
+                required_conditions: [],
+                speculative_check_pr: null,
+            }),
+        );
+        const pill = row.querySelector("[data-mergify-state-pill]");
+        expect(pill.textContent).toContain("Dequeued");
+        const btn = row.querySelector("[data-mergify-queue-btn]");
+        expect(btn.getAttribute("data-mergify-queue-btn")).toBe("unqueued");
+    });
+
+    test("does not render draft-PR link when speculative_check_pr is null", () => {
+        const row = buildRichRow(payload({ speculative_check_pr: null }));
+        expect(row.querySelector("[data-mergify-spec-pr]")).toBeNull();
+    });
+
+    test("does not render draft-PR link when speculative_check_pr is not a positive integer", () => {
+        const row = buildRichRow(
+            payload({ speculative_check_pr: "12345; alert(1)" }),
+        );
+        expect(row.querySelector("[data-mergify-spec-pr]")).toBeNull();
+    });
+});
+
+describe("buildMergifyRow dispatcher", () => {
+    beforeEach(() => {
+        window.history.replaceState({}, "", "/acme/widget/pull/42");
+        document.body.innerHTML = "";
+        jest.resetModules();
+    });
+
+    test("renders legacy shape when mqPayload has no payload", () => {
+        // No payload available → buildLegacyRow path.
+        const row = buildMergifyRow();
+        expect(row.dataset.mergifyShape).toBe("legacy");
+        expect(row.getAttribute(MERGE_BOX_ROW_ATTR)).toBe("default");
+    });
+
+    test("renders rich shape when mqPayload has a payload", () => {
+        jest.isolateModules(() => {
+            jest.doMock("../mqPayload", () => ({
+                ...jest.requireActual("../mqPayload"),
+                getCurrent: () => ({
+                    source: "payload",
+                    payload: {
+                        version: 1,
+                        state: "checking",
+                        queue_rule_name: null,
+                        queued_at: null,
+                        estimated_time_of_merge: null,
+                        speculative_check_pr: null,
+                        required_conditions: [],
+                    },
+                }),
+            }));
+            const queue = require("../queue");
+            const row = queue.buildMergifyRow();
+            expect(row.dataset.mergifyShape).toBe("rich");
+            expect(
+                row.querySelector("[data-mergify-state-pill]").textContent,
+            ).toContain("Checking");
+        });
+    });
+
+    test("rows carry MERGE_BOX_ROW_ATTR with the requested variant so multiple instances can coexist", () => {
+        const a = buildMergifyRow("default");
+        const b = buildMergifyRow("sidebar");
+        document.body.appendChild(a);
+        document.body.appendChild(b);
+        expect(
+            document.querySelectorAll(`[${MERGE_BOX_ROW_ATTR}]`),
+        ).toHaveLength(2);
+        expect(a.getAttribute(MERGE_BOX_ROW_ATTR)).toBe("default");
+        expect(b.getAttribute(MERGE_BOX_ROW_ATTR)).toBe("sidebar");
+        expect(a.id).toBe(""); // no id collision possible
+        expect(b.id).toBe("");
+    });
+});
+
+const { startEtaTicker, stopEtaTicker } = require("../queue");
+
+describe("ETA ticker", () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+        window.history.replaceState({}, "", "/acme/widget/pull/42");
+        document.body.innerHTML = "";
+    });
+    afterEach(() => {
+        stopEtaTicker();
+        jest.useRealTimers();
+    });
+
+    test("updates [data-mergify-eta] text every second while mounted", () => {
+        const payload = {
+            version: 1,
+            state: "checking",
+            queue_rule_name: null,
+            queued_at: "2026-05-29T10:20:00Z",
+            estimated_time_of_merge: new Date(Date.now() + 90000).toISOString(),
+            speculative_check_pr: null,
+            required_conditions: [],
+        };
+        const row = buildRichRow(payload);
+        document.body.appendChild(row);
+        startEtaTicker(payload);
+        const meta = row.querySelector("[data-mergify-eta]");
+        const before = meta.innerHTML;
+
+        jest.setSystemTime(new Date(Date.now() + 60000));
+        jest.advanceTimersByTime(1000);
+        const after = meta.innerHTML;
+        expect(after).not.toBe(before);
+    });
+
+    test("stopEtaTicker clears the interval", () => {
+        const payload = {
+            version: 1,
+            state: "checking",
+            queue_rule_name: null,
+            queued_at: null,
+            estimated_time_of_merge: new Date(Date.now() + 60000).toISOString(),
+            speculative_check_pr: null,
+            required_conditions: [],
+        };
+        const row = buildRichRow(payload);
+        document.body.appendChild(row);
+        startEtaTicker(payload);
+        stopEtaTicker();
+        const meta = row.querySelector("[data-mergify-eta]");
+        const before = meta.innerHTML;
+        jest.setSystemTime(new Date(Date.now() + 60000));
+        jest.advanceTimersByTime(2000);
+        expect(meta.innerHTML).toBe(before);
+    });
+
+    test("stops ticker when the row is removed from the DOM", () => {
+        const payload = {
+            version: 1,
+            state: "checking",
+            queue_rule_name: null,
+            queued_at: null,
+            estimated_time_of_merge: new Date(Date.now() + 90000).toISOString(),
+            speculative_check_pr: null,
+            required_conditions: [],
+        };
+        const row = buildRichRow(payload);
+        document.body.appendChild(row);
+        startEtaTicker(payload);
+        const meta = row.querySelector("[data-mergify-eta]");
+        row.remove();
+        const before = meta.innerHTML;
+        jest.setSystemTime(new Date(Date.now() + 60000));
+        jest.advanceTimersByTime(2000);
+        expect(meta.innerHTML).toBe(before);
+    });
+
+    test("stopEtaTicker on a row that was removed from the DOM does not keep ticking", () => {
+        const payload = {
+            version: 1,
+            state: "checking",
+            queue_rule_name: null,
+            queued_at: null,
+            estimated_time_of_merge: new Date(Date.now() + 90000).toISOString(),
+            speculative_check_pr: null,
+            required_conditions: [],
+        };
+        const richRow = buildRichRow(payload);
+        document.body.appendChild(richRow);
+        startEtaTicker(payload);
+        const meta = richRow.querySelector("[data-mergify-eta]");
+        const before = meta.innerHTML;
+        // Simulate the row being torn out from under us (shape-flip / SPA nav).
+        richRow.remove();
+        jest.setSystemTime(new Date(Date.now() + 60000));
+        jest.advanceTimersByTime(2000);
+        // The detached meta should not be updated, and the ticker should
+        // self-stop once no rows remain in the document.
+        expect(meta.innerHTML).toBe(before);
+    });
+
+    test("startEtaTicker is a no-op when payload has no estimated_time_of_merge", () => {
+        const payload = {
+            version: 1,
+            state: "waiting",
+            queue_rule_name: null,
+            queued_at: null,
+            estimated_time_of_merge: null,
+            speculative_check_pr: null,
+            required_conditions: [],
+        };
+        const row = buildRichRow(payload);
+        document.body.appendChild(row);
+        startEtaTicker(payload);
+        const meta = row.querySelector("[data-mergify-eta]");
+        const before = meta.innerHTML;
+        jest.setSystemTime(new Date(Date.now() + 60000));
+        jest.advanceTimersByTime(2000);
+        expect(meta.innerHTML).toBe(before);
+    });
+
+    test("regression: ticker updates every mounted row, not just one", () => {
+        // The bottom mergebox and the side peek both host a row. A single
+        // startEtaTicker call must update [data-mergify-eta] on every one.
+        const payload = {
+            version: 1,
+            state: "checking",
+            queue_rule_name: null,
+            queued_at: null,
+            estimated_time_of_merge: new Date(Date.now() + 90000).toISOString(),
+            speculative_check_pr: null,
+            required_conditions: [],
+        };
+        const a = buildRichRow(payload);
+        const b = buildRichRow(payload);
+        document.body.appendChild(a);
+        document.body.appendChild(b);
+        startEtaTicker(payload);
+        const metaA = a.querySelector("[data-mergify-eta]");
+        const metaB = b.querySelector("[data-mergify-eta]");
+        const beforeA = metaA.innerHTML;
+        const beforeB = metaB.innerHTML;
+        jest.setSystemTime(new Date(Date.now() + 60000));
+        jest.advanceTimersByTime(1000);
+        expect(metaA.innerHTML).not.toBe(beforeA);
+        expect(metaB.innerHTML).not.toBe(beforeB);
+    });
+});
+
+const { scheduleQueueStatePoll, QUEUE_POLL_INTERVAL } = require("../queue");
+
+describe("scheduleQueueStatePoll", () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+        window.history.replaceState({}, "", "/acme/widget/pull/42");
+        global.fetch = jest.fn(() =>
+            Promise.resolve({ ok: false, text: () => Promise.resolve("") }),
+        );
+    });
+    afterEach(() => {
+        jest.useRealTimers();
+        jest.restoreAllMocks();
+    });
+
+    test("regression: poll callback runs without ReferenceError (isGitHubPullRequestPage import survives)", async () => {
+        // The scheduled callback dereferences isGitHubPullRequestPage from
+        // ./dom.js — if the import is dropped (as happened during the
+        // PR #494 reconcile) the timer fires a ReferenceError 15s later
+        // and the legacy fallback poll is permanently broken.
+        scheduleQueueStatePoll();
+        await jest.advanceTimersByTimeAsync(QUEUE_POLL_INTERVAL + 100);
+        // Pass iff no exception escapes.
+    });
+});

--- a/src/__tests__/resetForNavigation.test.js
+++ b/src/__tests__/resetForNavigation.test.js
@@ -1,0 +1,19 @@
+const mqPayloadModule = require("../mqPayload");
+
+jest.mock("../mqPayload", () => {
+    // swc-compiled ESM exports are non-configurable, so `jest.spyOn` can't
+    // wrap them on the live module. Mock attach/detach as jest.fn() while
+    // preserving the rest of the real module via requireActual.
+    const actual = jest.requireActual("../mqPayload");
+    return { ...actual, attach: jest.fn(), detach: jest.fn() };
+});
+
+const { resetForNavigation } = require("../mergify");
+
+describe("resetForNavigation", () => {
+    test("calls mqPayload.detach in addition to resetQueueState", () => {
+        mqPayloadModule.detach.mockClear();
+        resetForNavigation();
+        expect(mqPayloadModule.detach).toHaveBeenCalled();
+    });
+});

--- a/src/mergify.js
+++ b/src/mergify.js
@@ -16,6 +16,7 @@ import {
 } from "./cache.js";
 import { debug } from "./debug.js";
 import { getPullRequestData, isGitHubPullRequestPage } from "./dom.js";
+import * as mqPayload from "./mqPayload.js";
 import {
     buildMergifyRow,
     fetchQueueStateIfNeeded,
@@ -24,6 +25,8 @@ import {
     MERGE_BOX_ROW_ATTR,
     resetQueueState,
     scheduleQueueStatePoll,
+    startEtaTicker,
+    stopEtaTicker,
     updateAllMergifyRows,
 } from "./queue.js";
 import { renderMergifyContext } from "./stacks.js";
@@ -61,9 +64,12 @@ let lastPullRequestUrl = null;
 let injecting = false;
 let pendingInjection = false;
 let pageUpdateScheduled = false;
+let _mqAttached = false;
 
 export function resetForNavigation() {
     resetQueueState(); // also calls resetStackState internally
+    mqPayload.detach();
+    _mqAttached = false;
     lastPullRequestUrl = null;
 }
 
@@ -206,6 +212,27 @@ async function _tryInject() {
 
     if (document.querySelector(`[${MERGE_BOX_ROW_ATTR}]`)) {
         scheduleQueueStatePoll();
+    }
+
+    // Subscribe to engine-authoritative merge-queue payloads (PR #32922).
+    // When a status comment with a payload exists, mqPayload emits payload
+    // states and we re-render every row in the rich shape; when none exists,
+    // it emits fallback states that pass through to the legacy patch path.
+    // Both lifecycles flow through updateAllMergifyRows so all containers
+    // (bottom mergebox + side peek) stay in sync.
+    if (!_mqAttached) {
+        _mqAttached = true;
+        mqPayload.attach((state) => {
+            updateAllMergifyRows();
+            if (
+                state.source === "payload" &&
+                state.payload.estimated_time_of_merge
+            ) {
+                startEtaTicker(state.payload);
+            } else {
+                stopEtaTicker();
+            }
+        });
     }
 }
 

--- a/src/mqPayload.js
+++ b/src/mqPayload.js
@@ -1,0 +1,368 @@
+import { debug } from "./debug.js";
+import { getPullRequestData, isGitHubPullRequestPage } from "./dom.js";
+import { fetchQueueState, QUEUE_POLL_INTERVAL } from "./queue.js";
+
+export const PAYLOAD_VERSION = 1;
+
+const PAYLOAD_STATES = new Set([
+    "waiting",
+    "checking",
+    "frozen",
+    "bisecting",
+    "merged",
+    "dequeued",
+]);
+
+// Mirrors engine's MERGIFY_COMMENT_PAYLOAD_REGEX (see hidden_payload.py).
+// The `m` flag lets `^` anchor at the start of any line, so the marker
+// block matches even when wrapped inside `<!--- ... -->`.
+const MARKER_REGEX =
+    /^DO NOT EDIT\n-\*- Mergify Payload -\*-\n(.+)\n-\*- Mergify Payload End -\*-/m;
+
+// Quick marker test that skips the JSON capture group for fast detection.
+const MARKER_PRESENT_REGEX = /-\*- Mergify Payload -\*-/;
+
+export function parsePayload(commentSource) {
+    if (typeof commentSource !== "string") return null;
+    const match = MARKER_REGEX.exec(commentSource);
+    if (!match) return null;
+
+    let raw;
+    try {
+        raw = JSON.parse(match[1]);
+    } catch (err) {
+        debug("mqPayload: invalid JSON", err);
+        return null;
+    }
+
+    if (!raw || typeof raw !== "object") return null;
+    if (typeof raw.version !== "number") return null;
+    if (raw.version > PAYLOAD_VERSION) {
+        debug(
+            "mqPayload: payload version",
+            raw.version,
+            "exceeds supported",
+            PAYLOAD_VERSION,
+        );
+        return null;
+    }
+    if (!PAYLOAD_STATES.has(raw.state)) return null;
+    if (!Array.isArray(raw.required_conditions)) return null;
+
+    return raw;
+}
+
+// Pull the raw markdown source out of an inline edit-form <textarea>.
+// GitHub renders these only when the user has opened/expanded the comment
+// edit form (or sometimes preemptively on hover). When present, they hold
+// the unrendered markdown — including HTML comments — verbatim.
+function _readInlineTextareaSource(timelineItem) {
+    const ta = timelineItem.querySelector(
+        "textarea.CommentBox-input, textarea.js-comment-field",
+    );
+    if (!ta) return null;
+    // Prefer the live `.value` (reflects user edits / engine updates)
+    // and fall back to textContent for environments that don't set `.value`.
+    const src = ta.value != null && ta.value !== "" ? ta.value : ta.textContent;
+    return typeof src === "string" ? src : null;
+}
+
+// Find the issuecomment numeric ID for a TimelineItem if the item is hosted
+// inside (or contains) an `id="issuecomment-<n>"` container.
+function _readCommentIdFor(timelineItem) {
+    const idHolder =
+        timelineItem.closest('[id^="issuecomment-"]') ||
+        timelineItem.querySelector('[id^="issuecomment-"]');
+    if (!idHolder) return null;
+    const m = /^issuecomment-(\d+)$/.exec(idHolder.id);
+    return m ? m[1] : null;
+}
+
+// Walk the timeline and find every Mergify-authored TimelineItem along with
+// any inline source / fetchable comment id we can pull a payload from.
+// Returns an array in DOM order: [{ item, inlineSource, commentId }].
+function _collectMergifyCandidates(root = document) {
+    const items = root.querySelectorAll(".TimelineItem");
+    const out = [];
+    for (const item of items) {
+        if (!item.querySelector('a[href="/apps/mergify"]')) continue;
+        const inlineSource = _readInlineTextareaSource(item);
+        const commentId = _readCommentIdFor(item);
+        out.push({ item, inlineSource, commentId });
+    }
+    return out;
+}
+
+// Resolve the latest Mergify status comment's payload synchronously, using
+// only inline DOM data (no network). Returns { payload, commentId } if the
+// inline textarea route works, or { payload: null, commentId } if we found
+// a fetchable candidate but no inline marker — `commentId` is then usable
+// for the async fetch fallback. Returns null if no Mergify comment exists.
+//
+// Most Mergify-authored TimelineItems are events (labels, reviewers, queue
+// breadcrumbs) without a payload marker; only status comments carry it.
+// Walking the candidate list in reverse and returning the first one with a
+// marker correctly picks the latest status comment instead of the
+// latest-anything-Mergify-touched.
+export function findLatestStatusCommentSync(root = document) {
+    const candidates = _collectMergifyCandidates(root);
+    if (candidates.length === 0) return null;
+
+    for (let i = candidates.length - 1; i >= 0; i--) {
+        const c = candidates[i];
+        if (c.inlineSource && MARKER_PRESENT_REGEX.test(c.inlineSource)) {
+            return {
+                payload: parsePayload(c.inlineSource),
+                commentId: c.commentId,
+            };
+        }
+    }
+
+    // No inline marker found. Fall back to the latest candidate that hosts an
+    // issuecomment-* node so the async fetch can try its edit_form. Events
+    // without a commentId aren't fetchable; skip them.
+    for (let i = candidates.length - 1; i >= 0; i--) {
+        if (candidates[i].commentId) {
+            return { payload: null, commentId: candidates[i].commentId };
+        }
+    }
+
+    return null;
+}
+
+async function _fetchCommentMarkdown(commentId) {
+    const data = getPullRequestData();
+    if (!data?.org || !data.repo) return null;
+    try {
+        const r = await fetch(
+            `/${data.org}/${data.repo}/issue_comments/${commentId}/edit_form`,
+        );
+        if (!r.ok) return null;
+        const html = await r.text();
+        const doc = new DOMParser().parseFromString(html, "text/html");
+        const ta = doc.querySelector("textarea");
+        return ta ? ta.value || ta.textContent || "" : null;
+    } catch (e) {
+        debug("mqPayload: edit_form fetch failed", e);
+        return null;
+    }
+}
+
+// Resolve the latest Mergify status comment's payload, falling back to a
+// network fetch of the comment's edit_form when the inline textarea isn't
+// materialized. Returns { payload, commentId } or null when there's no
+// Mergify status comment at all.
+export async function resolveLatestStatusCommentPayload(root = document) {
+    const sync = findLatestStatusCommentSync(root);
+    if (!sync) return null;
+    if (sync.payload) return sync;
+    if (!sync.commentId) return { payload: null, commentId: null };
+    const markdown = await _fetchCommentMarkdown(sync.commentId);
+    if (!markdown) return { payload: null, commentId: sync.commentId };
+    const payload = parsePayload(markdown);
+    return { payload, commentId: sync.commentId };
+}
+
+let _onChange = null;
+let _current = null;
+
+// Payload-side state.
+let _payloadGeneration = 0;
+let _payloadPollTimer = null;
+let _timelineObserver = null;
+let _inPayloadMode = false;
+
+// Fallback-side state (preserved from previous implementation).
+let _fallbackTimer = null;
+let _fallbackGeneration = 0;
+
+function _equal(a, b) {
+    return JSON.stringify(a) === JSON.stringify(b);
+}
+
+function _emit(state) {
+    if (!_onChange) return;
+    if (_equal(state, _current)) return;
+    _current = state;
+    _onChange(state);
+}
+
+async function _runFallbackPoll() {
+    const generation = _fallbackGeneration;
+    const queued = await fetchQueueState();
+    if (generation !== _fallbackGeneration) return;
+    if (!_onChange) return;
+    _emit({ source: "fallback", queued: !!queued });
+}
+
+function _scheduleFallbackPoll() {
+    if (_fallbackTimer != null) return;
+    const generation = _fallbackGeneration;
+    _fallbackTimer = setTimeout(async () => {
+        _fallbackTimer = null;
+        if (generation !== _fallbackGeneration) return;
+        if (!isGitHubPullRequestPage()) return;
+        await _runFallbackPoll();
+        if (generation !== _fallbackGeneration) return;
+        if (isGitHubPullRequestPage() && _onChange) _scheduleFallbackPoll();
+    }, QUEUE_POLL_INTERVAL);
+}
+
+function _startFallback() {
+    void _runFallbackPoll();
+    _scheduleFallbackPoll();
+}
+
+function _stopFallback() {
+    _fallbackGeneration++;
+    if (_fallbackTimer != null) {
+        clearTimeout(_fallbackTimer);
+        _fallbackTimer = null;
+    }
+}
+
+// Re-resolve the latest Mergify status comment and emit if its payload has
+// changed. This is the freshness mechanism for payload mode. It MUST be
+// triggered by both a periodic timer AND the timeline observer, because:
+//
+//   - The timeline observer (MutationObserver on document.body) catches DOM
+//     tree mutations: new comments appearing, comments being edited (which
+//     re-renders the body), etc.
+//   - The periodic timer is load-bearing because inline `.value` mutations
+//     on a <textarea> do NOT fire MutationObserver. MO observes DOM tree
+//     mutations, not property assignments. If the engine updates the
+//     payload by silently rewriting the textarea's `.value` (no DOM
+//     reflow), only the periodic re-read picks it up.
+async function _resolveAndEmit() {
+    const generation = _payloadGeneration;
+    let result;
+    try {
+        result = await resolveLatestStatusCommentPayload();
+    } catch (e) {
+        debug("mqPayload: resolveLatestStatusCommentPayload threw", e);
+        return;
+    }
+    if (generation !== _payloadGeneration) return;
+    if (!_onChange) return;
+
+    if (!result) {
+        debug("mqPayload: resolve returned null (no Mergify comment found)");
+        return;
+    }
+    debug(
+        "mqPayload: resolve returned",
+        result.payload
+            ? `payload(state=${result.payload.state})`
+            : "null payload",
+        "commentId=",
+        result.commentId,
+    );
+    if (result.payload) {
+        if (!_inPayloadMode) {
+            _stopFallback();
+            _inPayloadMode = true;
+        }
+        _emit({ source: "payload", payload: result.payload });
+    }
+}
+
+function _schedulePayloadPoll() {
+    if (_payloadPollTimer != null) return;
+    const generation = _payloadGeneration;
+    _payloadPollTimer = setTimeout(async () => {
+        _payloadPollTimer = null;
+        if (generation !== _payloadGeneration) return;
+        if (!isGitHubPullRequestPage()) return;
+        await _resolveAndEmit();
+        if (generation !== _payloadGeneration) return;
+        if (isGitHubPullRequestPage() && _onChange) _schedulePayloadPoll();
+    }, QUEUE_POLL_INTERVAL);
+}
+
+const TIMELINE_OBSERVER_DEBOUNCE_MS = 800;
+let _timelineObserverDebounce = null;
+
+function _installTimelineObserver() {
+    if (_timelineObserver) return;
+    _timelineObserver = new MutationObserver(() => {
+        if (!_onChange) return;
+        // Once we're in payload mode, the periodic poll (QUEUE_POLL_INTERVAL)
+        // owns freshness — refetching edit_form on every page mutation would
+        // hammer GitHub. The engine edits the same status comment in place;
+        // there's no second one to catch.
+        if (_inPayloadMode) return;
+        // Coalesce bursts of mutations (GitHub re-renders heavily on PR
+        // pages) into a single resolve attempt at the tail.
+        if (_timelineObserverDebounce != null) {
+            clearTimeout(_timelineObserverDebounce);
+        }
+        _timelineObserverDebounce = setTimeout(() => {
+            _timelineObserverDebounce = null;
+            void _resolveAndEmit();
+        }, TIMELINE_OBSERVER_DEBOUNCE_MS);
+    });
+    _timelineObserver.observe(document.body, {
+        childList: true,
+        subtree: true,
+    });
+}
+
+export function attach(callback) {
+    detach();
+    _onChange = callback;
+
+    const sync = findLatestStatusCommentSync();
+    debug(
+        "mqPayload: attach() sync resolve =",
+        sync == null
+            ? "null"
+            : sync.payload
+              ? `payload(state=${sync.payload.state})`
+              : `null payload, commentId=${sync.commentId}`,
+    );
+    if (sync?.payload) {
+        _inPayloadMode = true;
+        _emit({ source: "payload", payload: sync.payload });
+        _installTimelineObserver();
+        _schedulePayloadPoll();
+        return;
+    }
+
+    // No sync payload. Two sub-cases:
+    //  - We found a Mergify status comment but its source isn't inline
+    //    (no marker in textarea, or no textarea at all) → kick the async
+    //    resolver and run legacy fallback in the meantime.
+    //  - No Mergify comment in the timeline at all → pure fallback mode +
+    //    timeline observer so we upgrade as soon as one appears.
+    _startFallback();
+    _installTimelineObserver();
+    _schedulePayloadPoll();
+
+    if (sync?.commentId) {
+        void _resolveAndEmit();
+    }
+}
+
+export function detach() {
+    _payloadGeneration++;
+    if (_timelineObserver) {
+        _timelineObserver.disconnect();
+        _timelineObserver = null;
+    }
+    if (_timelineObserverDebounce != null) {
+        clearTimeout(_timelineObserverDebounce);
+        _timelineObserverDebounce = null;
+    }
+    if (_payloadPollTimer != null) {
+        clearTimeout(_payloadPollTimer);
+        _payloadPollTimer = null;
+    }
+    _stopFallback();
+    _inPayloadMode = false;
+    _current = null;
+    _onChange = null;
+}
+
+export function getCurrent() {
+    return _current;
+}

--- a/src/queue.js
+++ b/src/queue.js
@@ -8,6 +8,20 @@ const QUEUE_ICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 
 
 const LOGS_ICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="14" height="14" fill="currentColor" aria-hidden="true" focusable="false"><path d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0Zm0 1.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 4.75a.75.75 0 0 1 1.5 0v3.44l1.97 1.97a.75.75 0 1 1-1.06 1.06l-2.19-2.19a.75.75 0 0 1-.22-.53Z"/></svg>`;
 
+export function formatEta(etaIso, now = Date.now()) {
+    if (etaIso == null) return "";
+    const eta = Date.parse(etaIso);
+    if (Number.isNaN(eta)) return "";
+    const deltaMs = eta - now;
+    if (deltaMs < 0) {
+        const overdueMin = Math.round(-deltaMs / 60000);
+        return `overdue by ${overdueMin}m`;
+    }
+    if (deltaMs <= 5000) return "any moment";
+    if (deltaMs < 60000) return `~${Math.round(deltaMs / 1000)}s`;
+    return `~${Math.round(deltaMs / 60000)}m`;
+}
+
 export const BUTTONS = [
     {
         command: "refresh",
@@ -57,6 +71,12 @@ export let queueStateInitialized = false;
 export let queuePollTimer = null;
 export const QUEUE_POLL_INTERVAL = 15000;
 
+// Marker for the rows we inject. Use a data attribute rather than an id so
+// the row can coexist multiple times across the legacy merge box and the new
+// merge-status sidebar without clashing on uniqueness. Also avoids matching
+// GitHub's native <section id="mergify"> for the Mergify GitHub App check.
+export const MERGE_BOX_ROW_ATTR = "data-mergify-merge-box-row";
+
 export function resetQueueState() {
     lastKnownQueueState = false;
     queueStateInitialized = false;
@@ -64,7 +84,26 @@ export function resetQueueState() {
         clearTimeout(queuePollTimer);
         queuePollTimer = null;
     }
+    stopEtaTicker();
     resetStackState();
+}
+
+export async function fetchQueueStateIfNeeded() {
+    if (queueStateInitialized) return;
+    queueStateInitialized = true;
+    await fetchQueueState();
+}
+
+export function scheduleQueueStatePoll() {
+    if (queuePollTimer) return;
+    queuePollTimer = setTimeout(async () => {
+        queuePollTimer = null;
+        if (!isGitHubPullRequestPage()) return;
+        const previousState = lastKnownQueueState;
+        await fetchQueueState();
+        if (previousState !== lastKnownQueueState) updateAllMergifyRows();
+        if (isGitHubPullRequestPage()) scheduleQueueStatePoll();
+    }, QUEUE_POLL_INTERVAL);
 }
 
 export function isMergifyQueueCheckQueued(text) {
@@ -187,12 +226,6 @@ export function isPullRequestQueued() {
     return lastKnownQueueState;
 }
 
-export async function fetchQueueStateIfNeeded() {
-    if (queueStateInitialized) return;
-    queueStateInitialized = true;
-    await fetchQueueState();
-}
-
 export async function fetchQueueState() {
     const urlAtFetch = window.location.pathname;
     const data = getPullRequestData();
@@ -202,13 +235,13 @@ export async function fetchQueueState() {
         const checksResponse = await fetch(
             `/${data.org}/${data.repo}/pull/${data.pull}/checks`,
         );
-        if (window.location.pathname !== urlAtFetch) return;
+        if (window.location.pathname !== urlAtFetch) return lastKnownQueueState;
         if (!checksResponse.ok) {
             debug(
                 "fetchQueueState: checks page returned",
                 checksResponse.status,
             );
-            return;
+            return lastKnownQueueState;
         }
 
         const checksHtml = await checksResponse.text();
@@ -223,7 +256,7 @@ export async function fetchQueueState() {
         if (!match) {
             debug("fetchQueueState: no Mergify Merge Queue check run found");
             lastKnownQueueState = false;
-            return;
+            return lastKnownQueueState;
         }
 
         debug("fetchQueueState: found check_run_id", match[1]);
@@ -232,10 +265,10 @@ export async function fetchQueueState() {
         const runResponse = await fetch(
             `/${data.org}/${data.repo}/runs/${match[1]}`,
         );
-        if (window.location.pathname !== urlAtFetch) return;
+        if (window.location.pathname !== urlAtFetch) return lastKnownQueueState;
         if (!runResponse.ok) {
             debug("fetchQueueState: run page returned", runResponse.status);
-            return;
+            return lastKnownQueueState;
         }
 
         const runHtml = await runResponse.text();
@@ -244,6 +277,7 @@ export async function fetchQueueState() {
     } catch (error) {
         debug("Failed to fetch queue state:", error);
     }
+    return lastKnownQueueState;
 }
 
 export function findLastMergifyCommand() {
@@ -301,7 +335,9 @@ export function postCommand(command) {
 
 export function postCommandAndUpdate(command) {
     postCommand(command);
-    updateAllMergifyRows();
+    for (const row of document.querySelectorAll(`[${MERGE_BOX_ROW_ATTR}]`)) {
+        updateMergifyRow(row);
+    }
 }
 
 export function buildMergeBoxButton(
@@ -329,6 +365,8 @@ export function buildMergeBoxButton(
         height: 32px;
         line-height: 21px;
         padding: 0 12px;
+        white-space: nowrap;
+        flex-shrink: 0;
     `;
 
     if (variant === "primary") {
@@ -411,26 +449,27 @@ export function getMergeQueueLink() {
     return `https://dashboard.mergify.com/queues?login=${data.org}&repository=${data.repo}&branch=main&pull-request-number=${data.pull}`;
 }
 
-// Marker for the rows we inject. Use a data attribute rather than an id so
-// the row can coexist multiple times across the legacy merge box and the new
-// merge-status sidebar without clashing on uniqueness. Also avoids matching
-// GitHub's native <section id="mergify"> for the Mergify GitHub App check.
-export const MERGE_BOX_ROW_ATTR = "data-mergify-merge-box-row";
+// Read the current payload from mqPayload via lazy require to sidestep the
+// circular dependency (mqPayload.js imports fetchQueueState from this module).
+function _currentPayload() {
+    try {
+        const cur = require("./mqPayload.js").getCurrent();
+        return cur && cur.source === "payload" ? cur.payload : null;
+    } catch (_e) {
+        return null;
+    }
+}
 
-export function buildMergifyRow(variant = "default") {
-    if (variant === "sidebar") return buildMergifySidebarRow();
-
+function buildLegacyDefaultRow() {
     const state = deriveQueueButtonState();
 
     const row = document.createElement("div");
-    // Variant is stored on the attribute so updateMergifyRow can rebuild
-    // the row in the same style when state transitions from open to
-    // merged/closed.
     row.setAttribute(MERGE_BOX_ROW_ATTR, "default");
+    row.dataset.mergifyShape = "legacy";
     row.className =
         "bgColor-muted borderColor-muted border-top rounded-bottom-2";
     row.style.cssText =
-        "display:flex;align-items:center;gap:8px;padding:var(--base-size-16,16px)!important;";
+        "display:flex;align-items:center;gap:8px;padding:var(--base-size-16,16px)!important;flex-wrap:wrap;";
 
     if (state !== "merged" && state !== "closed") {
         const buttons = document.createElement("div");
@@ -450,69 +489,40 @@ export function buildMergifyRow(variant = "default") {
         row.appendChild(buttons);
     }
 
-    const info = document.createElement("div");
-    info.style.cssText =
-        "display:flex;align-items:center;gap:12px;font-size:14px;margin-left:auto;";
-
-    function appendLink(href, text, iconSvg) {
-        const link = document.createElement("a");
-        link.href = href;
-        link.target = "_blank";
-        link.rel = "noopener noreferrer";
-        link.style.cssText =
-            "color:var(--fgColor-accent, #58a6ff);text-decoration:none;display:inline-flex;align-items:center;gap:4px;";
-        link.appendChild(parseSvg(iconSvg));
-        link.appendChild(document.createTextNode(text));
-        info.appendChild(link);
-    }
-
-    appendLink(getMergeQueueLink(), "queue", QUEUE_ICON_SVG);
-    appendLink(getEventLogLink(), "logs", LOGS_ICON_SVG);
+    const info = buildBrandAndLinks();
 
     if (state === "merged") {
         const status = document.createElement("span");
         status.style.color = "var(--fgColor-muted, #7d8590)";
         status.textContent = getMergedMessage();
-        info.appendChild(status);
+        // The brand anchor is the last child of the info div returned by
+        // buildBrandAndLinks(); insert the merged status before it so the
+        // visual order (queue link, logs link, merged message, brand) is
+        // preserved.
+        info.insertBefore(status, info.lastChild);
     }
-
-    const brand = document.createElement("a");
-    brand.href = "https://dashboard.mergify.com";
-    brand.target = "_blank";
-    brand.rel = "noopener noreferrer";
-    brand.title = "Open Mergify dashboard";
-    brand.style.cssText =
-        "display:flex;align-items:center;gap:6px;margin-left:8px;color:var(--fgColor-default, #e6edf3);text-decoration:none;font-weight:600;";
-    const svgEl = parseSvg(getLogoSvg());
-    svgEl.setAttribute("width", "20");
-    svgEl.setAttribute("height", "20");
-    brand.appendChild(svgEl);
-    const brandText = document.createElement("span");
-    brandText.textContent = "Mergify";
-    brand.appendChild(brandText);
-    info.appendChild(brand);
 
     row.appendChild(info);
 
     return row;
 }
 
-function buildMergifySidebarRow() {
+function buildLegacySidebarRow() {
     const state = deriveQueueButtonState();
 
     const row = document.createElement("div");
     row.setAttribute(MERGE_BOX_ROW_ATTR, "sidebar");
+    row.dataset.mergifyShape = "legacy";
     // Two-line layout that matches the surrounding native sections (border
     // rules on top and bottom, no muted background); action buttons on line
-    // one, queue/logs on the left of line two and Mergify brand on the
-    // right.
+    // one, queue/logs on the left of line two and Mergify brand on the right.
     row.className = "border-top border-bottom color-border-subtle";
     row.style.cssText =
         "display:flex;flex-direction:column;gap:8px;padding:var(--base-size-16,16px)!important;margin-top:var(--base-size-24,24px);";
 
     if (state !== "merged" && state !== "closed") {
         const buttons = document.createElement("div");
-        buttons.style.cssText = "display:flex;gap:6px;";
+        buttons.style.cssText = "display:flex;gap:6px;flex-wrap:wrap;";
         buttons.appendChild(buildQueueButton(state));
         for (const btn of BUTTONS) {
             buttons.appendChild(
@@ -532,10 +542,13 @@ function buildMergifySidebarRow() {
     secondLine.style.cssText =
         "display:flex;align-items:center;justify-content:space-between;gap:8px;";
 
+    // Sidebar's second line keeps queue+logs (and any merged-message badge)
+    // on the left, with the Mergify brand pinned to the right via
+    // justify-content:space-between. Mirrors PR #494's structure so the
+    // dashboard-link tests pass.
     const links = document.createElement("div");
     links.style.cssText =
         "display:flex;align-items:center;gap:12px;font-size:14px;";
-
     function appendLink(href, text, iconSvg) {
         const link = document.createElement("a");
         link.href = href;
@@ -547,10 +560,8 @@ function buildMergifySidebarRow() {
         link.appendChild(document.createTextNode(text));
         links.appendChild(link);
     }
-
     appendLink(getMergeQueueLink(), "queue", QUEUE_ICON_SVG);
     appendLink(getEventLogLink(), "logs", LOGS_ICON_SVG);
-
     if (state === "merged") {
         const status = document.createElement("span");
         status.style.color = "var(--fgColor-muted, #7d8590)";
@@ -574,10 +585,20 @@ function buildMergifySidebarRow() {
     brandText.textContent = "Mergify";
     brand.appendChild(brandText);
     secondLine.appendChild(brand);
-
     row.appendChild(secondLine);
 
     return row;
+}
+
+function buildLegacyRow(variant = "default") {
+    if (variant === "sidebar") return buildLegacySidebarRow();
+    return buildLegacyDefaultRow();
+}
+
+export function buildMergifyRow(variant = "default") {
+    const payload = _currentPayload();
+    if (payload) return buildRichRow(payload, variant);
+    return buildLegacyRow(variant);
 }
 
 export function updateAllMergifyRows() {
@@ -586,36 +607,464 @@ export function updateAllMergifyRows() {
 }
 
 export function updateMergifyRow(row) {
-    const state = deriveQueueButtonState();
-    const oldBtn = row.querySelector("[data-mergify-queue-btn]");
+    const variant = row.getAttribute(MERGE_BOX_ROW_ATTR) || "default";
+    const currentShape = row.dataset.mergifyShape || "legacy";
+    const payload = _currentPayload();
+    const incomingShape = payload ? "rich" : "legacy";
 
-    if (state === "merged" || state === "closed") {
-        if (oldBtn) {
-            // PR was open, now merged/closed — rebuild entire row, keeping
-            // the same variant so the sidebar styling survives the swap.
-            const variant = row.getAttribute(MERGE_BOX_ROW_ATTR) || "default";
-            const newRow = buildMergifyRow(variant);
-            row.replaceWith(newRow);
-            debug("Mergify row rebuilt for state:", state);
-        }
+    if (incomingShape !== currentShape) {
+        stopEtaTicker();
+        const replacement = payload
+            ? buildRichRow(payload, variant)
+            : buildLegacyRow(variant);
+        row.replaceWith(replacement);
+        debug("Mergify row swapped:", currentShape, "→", incomingShape);
         return;
     }
 
-    if (!oldBtn) return;
-    if (oldBtn.getAttribute("data-mergify-queue-btn") === state) return;
-    const newBtn = buildQueueButton(state);
-    oldBtn.replaceWith(newBtn);
-    debug("Queue button state:", state);
+    if (incomingShape === "rich") {
+        const next = buildRichRow(payload, variant);
+        // Snapshot the children before replaceChildren starts moving them.
+        // Spread already eagerly iterates, but Array.from makes the snapshot
+        // explicit so the live-NodeList shape can't trip up a future reader
+        // (or static analyzer) reasoning about iteration-during-mutation.
+        row.replaceChildren(...Array.from(next.childNodes));
+        _etaPayload = payload;
+        debug("Mergify rich row patched:", payload.state);
+        return;
+    }
+
+    _legacyPatch(row, variant);
 }
 
-export function scheduleQueueStatePoll() {
-    if (queuePollTimer) return;
-    queuePollTimer = setTimeout(async () => {
-        queuePollTimer = null;
-        if (!isGitHubPullRequestPage()) return;
-        const previousState = lastKnownQueueState;
-        await fetchQueueState();
-        if (previousState !== lastKnownQueueState) updateAllMergifyRows();
-        if (isGitHubPullRequestPage()) scheduleQueueStatePoll();
-    }, QUEUE_POLL_INTERVAL);
+function _legacyPatch(row, variant = "default") {
+    const derived = deriveQueueButtonState();
+    const oldBtn = row.querySelector("[data-mergify-queue-btn]");
+    if (derived === "merged" || derived === "closed") {
+        if (oldBtn) {
+            const newRow = buildLegacyRow(variant);
+            row.replaceWith(newRow);
+            debug("Mergify legacy row rebuilt for state:", derived);
+        }
+        return;
+    }
+    if (!oldBtn) return;
+    if (oldBtn.getAttribute("data-mergify-queue-btn") === derived) return;
+    const newBtn = buildQueueButton(derived);
+    oldBtn.replaceWith(newBtn);
+    debug("Legacy queue button state:", derived);
+}
+
+// Walk the condition tree and produce a flat list of short labels describing
+// what's still blocking the merge. Met conditions are skipped entirely.
+// "any of" groups collapse to a single "any of: a, b, c" line so the user
+// sees that ONE alternative is enough; all-of groups flatten transparently.
+function _collectBlockers(nodes) {
+    const out = [];
+    for (const n of nodes) {
+        if (n.match) continue;
+        if (!n.subconditions || n.subconditions.length === 0) {
+            out.push(n.description);
+            continue;
+        }
+        const desc = (n.description || "").toLowerCase();
+        if (desc.includes("any of") || desc.includes("not")) {
+            // Format inline so the disjunction/negation is visible at a glance.
+            const childTexts = n.subconditions
+                .filter((c) => !c.match)
+                .map((c) =>
+                    c.subconditions && c.subconditions.length > 0
+                        ? `(${_collectBlockers([c]).join(" · ")})`
+                        : c.description,
+                );
+            out.push(`${n.description} ${childTexts.join(", ")}`);
+        } else {
+            // "all of" or unnamed group — flatten unmet children transparently.
+            out.push(..._collectBlockers(n.subconditions));
+        }
+    }
+    return out;
+}
+
+export function renderConditionsBlock(conditions) {
+    if (!conditions || conditions.length === 0) return null;
+    const blockers = _collectBlockers(conditions);
+
+    const block = document.createElement("div");
+    block.setAttribute("data-mergify-conditions", "");
+    // No background fill — let the conditions block share the parent row's
+    // surface so it reads as a continuation of the state row above, with
+    // a subtle border + indent for separation.
+    block.style.cssText =
+        "padding:6px 16px 12px 40px;border-top:1px dashed var(--borderColor-muted, #30363d);";
+
+    const heading = document.createElement("h4");
+    heading.style.cssText =
+        "margin:0 0 6px;font-size:11px;text-transform:none;letter-spacing:0;color:#7d8590;font-weight:600;display:flex;align-items:center;gap:6px;";
+    if (blockers.length === 0) {
+        const allMet = document.createElement("span");
+        allMet.style.color = "#3fb950";
+        allMet.textContent = "✓ All required conditions met";
+        heading.appendChild(allMet);
+    } else {
+        heading.textContent =
+            blockers.length === 1
+                ? "Blocking the merge:"
+                : `Blocking the merge (${blockers.length}):`;
+    }
+    block.appendChild(heading);
+
+    for (const text of blockers) {
+        const row = document.createElement("div");
+        row.setAttribute("data-mergify-condition", "");
+        row.style.cssText =
+            "display:flex;align-items:flex-start;gap:8px;padding:2px 0;color:#c9d1d9;font-size:12px;";
+        const dot = document.createElement("span");
+        dot.className = "pending";
+        dot.style.cssText = "color:#dbab09;flex-shrink:0;line-height:1.4;";
+        dot.textContent = "●";
+        const label = document.createElement("span");
+        label.style.cssText =
+            "word-break:break-word;line-height:1.4;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:11px;";
+        label.textContent = text;
+        row.appendChild(dot);
+        row.appendChild(label);
+        block.appendChild(row);
+    }
+    return block;
+}
+
+const STATE_PILL_COPY = {
+    waiting: { label: "Waiting", note: "queued conditions not yet met" },
+    checking: { label: "Checking", note: "" },
+    frozen: { label: "Frozen", note: "queue paused — freeze in effect" },
+    bisecting: {
+        label: "Bisecting",
+        note: "train split — isolating a failure",
+    },
+    merged: { label: "Merged", note: "" },
+    dequeued: { label: "Dequeued", note: "removed from queue" },
+};
+
+const STATE_PILL_COLORS = {
+    waiting: {
+        bg: "#7d859022",
+        fg: "#c9d1d9",
+        border: "#7d859055",
+        pulse: false,
+    },
+    checking: {
+        // GitHub's CI in-progress yellow.
+        bg: "#dbab0922",
+        fg: "#dbab09",
+        border: "#dbab0966",
+        pulse: true,
+    },
+    frozen: {
+        bg: "#bb800922",
+        fg: "#e3b341",
+        border: "#bb800966",
+        pulse: false,
+    },
+    bisecting: {
+        bg: "#da363322",
+        fg: "#f85149",
+        border: "#da363366",
+        pulse: true,
+    },
+    merged: {
+        bg: "#3fb95022",
+        fg: "#3fb950",
+        border: "#3fb95055",
+        pulse: false,
+    },
+    dequeued: {
+        bg: "#da363322",
+        fg: "#f85149",
+        border: "#da363366",
+        pulse: false,
+    },
+};
+
+let _mqpStyleInjected = false;
+function ensurePulseKeyframes() {
+    if (_mqpStyleInjected) return;
+    _mqpStyleInjected = true;
+    const s = document.createElement("style");
+    s.textContent = "@keyframes mqp-pulse { 50% { opacity: .4; } }";
+    document.head.appendChild(s);
+}
+
+function buildStatePill(state) {
+    const pill = document.createElement("span");
+    pill.setAttribute("data-mergify-state-pill", "");
+    pill.setAttribute("data-state", state);
+    const c = STATE_PILL_COLORS[state];
+    pill.style.cssText = `display:inline-flex;align-items:center;gap:6px;padding:3px 10px;border-radius:20px;font-size:12px;font-weight:600;background:${c.bg};color:${c.fg};border:1px solid ${c.border};`;
+    const dot = document.createElement("span");
+    dot.style.cssText = `width:7px;height:7px;border-radius:50%;background:${c.fg};${c.pulse ? "animation:mqp-pulse 1.6s infinite;" : ""}`;
+    pill.appendChild(dot);
+    pill.appendChild(
+        document.createTextNode(` ${STATE_PILL_COPY[state].label}`),
+    );
+    return pill;
+}
+
+function buildSpecPrLink(org, repo, prNumber) {
+    const n = Number.parseInt(prNumber, 10);
+    if (!Number.isFinite(n) || n <= 0 || String(n) !== String(prNumber))
+        return null;
+    const a = document.createElement("a");
+    a.setAttribute("data-mergify-spec-pr", "");
+    a.href = `/${org}/${repo}/pull/${n}`;
+    a.title = `Open the draft pull request running CI for this merge`;
+    a.style.cssText = [
+        "display:inline-flex",
+        "align-items:center",
+        "gap:4px",
+        "padding:3px 10px",
+        "border-radius:6px",
+        "border:1px solid var(--button-default-borderColor-rest, #30363d)",
+        "background:var(--button-default-bgColor-rest, #21262d)",
+        "color:var(--button-default-fgColor-rest, #e6edf3)",
+        "font-size:12px",
+        "font-weight:500",
+        "text-decoration:none",
+        "white-space:nowrap",
+    ].join(";");
+    a.textContent = `Batch PR #${n} →`;
+    return a;
+}
+
+function buildBrandAndLinks() {
+    const info = document.createElement("div");
+    info.style.cssText =
+        "display:flex;align-items:center;gap:12px;font-size:14px;margin-left:auto;";
+
+    function appendLink(href, text, iconSvg) {
+        const link = document.createElement("a");
+        link.href = href;
+        link.target = "_blank";
+        link.rel = "noopener noreferrer";
+        link.style.cssText =
+            "color:var(--fgColor-accent, #58a6ff);text-decoration:none;display:inline-flex;align-items:center;gap:4px;";
+        link.appendChild(parseSvg(iconSvg));
+        link.appendChild(document.createTextNode(text));
+        info.appendChild(link);
+    }
+    appendLink(getMergeQueueLink(), "queue", QUEUE_ICON_SVG);
+    appendLink(getEventLogLink(), "logs", LOGS_ICON_SVG);
+
+    const brand = document.createElement("a");
+    brand.href = "https://dashboard.mergify.com";
+    brand.target = "_blank";
+    brand.rel = "noopener noreferrer";
+    brand.title = "Open Mergify dashboard";
+    brand.style.cssText =
+        "display:flex;align-items:center;gap:6px;margin-left:8px;color:var(--fgColor-default, #e6edf3);text-decoration:none;font-weight:600;";
+    const svgEl = parseSvg(getLogoSvg());
+    svgEl.setAttribute("width", "20");
+    svgEl.setAttribute("height", "20");
+    brand.appendChild(svgEl);
+    const brandText = document.createElement("span");
+    brandText.textContent = "Mergify";
+    brand.appendChild(brandText);
+    info.appendChild(brand);
+
+    return info;
+}
+
+function buildButtonsRow(queueButtonState) {
+    const row = document.createElement("div");
+    row.style.cssText =
+        "display:flex;align-items:center;gap:8px;padding:var(--base-size-16,16px)!important;flex-wrap:wrap;";
+    const buttons = document.createElement("div");
+    buttons.style.cssText = "display:flex;gap:6px;flex-wrap:wrap;";
+    buttons.appendChild(buildQueueButton(queueButtonState));
+    for (const btn of BUTTONS) {
+        buttons.appendChild(
+            buildMergeBoxButton(
+                btn.command,
+                btn.label,
+                btn.tooltip,
+                false,
+                "secondary",
+            ),
+        );
+    }
+    row.appendChild(buttons);
+    row.appendChild(buildBrandAndLinks());
+    return row;
+}
+
+// Format a duration in minutes as a short human-readable string. Stays in
+// `Nm` for short queue times, switches to `Hh Mm` once it exceeds an hour,
+// and to `Dd Hh` past a day so long-running queue waits stay legible
+// (e.g. 822m → `13h 42m`, 1500m → `1d 1h`).
+export function formatDurationMinutes(totalMinutes) {
+    const m = Math.max(0, Math.round(totalMinutes));
+    if (m < 60) return `${m}m`;
+    if (m < 24 * 60) {
+        const h = Math.floor(m / 60);
+        const rem = m % 60;
+        return rem === 0 ? `${h}h` : `${h}h ${rem}m`;
+    }
+    const d = Math.floor(m / (24 * 60));
+    const remH = Math.floor((m % (24 * 60)) / 60);
+    return remH === 0 ? `${d}d` : `${d}d ${remH}h`;
+}
+
+function buildEtaMetaContent(payload) {
+    const parts = [];
+    if (payload.queued_at) {
+        const frag = document.createDocumentFragment();
+        frag.appendChild(document.createTextNode("queued "));
+        const queuedMin = (Date.now() - Date.parse(payload.queued_at)) / 60000;
+        const strong = document.createElement("strong");
+        strong.style.color = "#e6edf3";
+        strong.textContent = `${formatDurationMinutes(queuedMin)} ago`;
+        frag.appendChild(strong);
+        parts.push(frag);
+    }
+    const etaStr = formatEta(payload.estimated_time_of_merge);
+    if (etaStr) {
+        const frag = document.createDocumentFragment();
+        frag.appendChild(document.createTextNode("merging "));
+        const strong = document.createElement("strong");
+        strong.style.color = "#e6edf3";
+        strong.textContent = etaStr;
+        frag.appendChild(strong);
+        parts.push(frag);
+    }
+    if (STATE_PILL_COPY[payload.state] && STATE_PILL_COPY[payload.state].note) {
+        parts.push(
+            document.createTextNode(STATE_PILL_COPY[payload.state].note),
+        );
+    }
+    // Interleave separators.
+    const out = [];
+    parts.forEach((frag, i) => {
+        if (i > 0) out.push(document.createTextNode(" · "));
+        out.push(frag);
+    });
+    return out;
+}
+
+function buildStateRow(payload, org, repo) {
+    const row = document.createElement("div");
+    row.style.cssText =
+        "display:flex;align-items:center;gap:10px;padding:10px var(--base-size-16,16px);border-top:1px solid var(--borderColor-muted, #30363d);";
+
+    // Brand prefix so it's unambiguous that this row reflects Mergify's
+    // merge-queue state, not some other GitHub status.
+    const brand = document.createElement("span");
+    brand.style.cssText =
+        "display:inline-flex;align-items:center;gap:6px;font-size:12px;font-weight:600;color:var(--fgColor-default, #e6edf3);";
+    const svgEl = parseSvg(getLogoSvg());
+    svgEl.setAttribute("width", "14");
+    svgEl.setAttribute("height", "14");
+    brand.appendChild(svgEl);
+    brand.appendChild(document.createTextNode("Merge Queue"));
+    row.appendChild(brand);
+
+    row.appendChild(buildStatePill(payload.state));
+
+    const meta = document.createElement("span");
+    meta.setAttribute("data-mergify-eta", "");
+    meta.style.cssText = "color:#7d8590;font-size:12px;";
+    for (const node of buildEtaMetaContent(payload)) {
+        meta.appendChild(node);
+    }
+    row.appendChild(meta);
+
+    const specLink = buildSpecPrLink(org, repo, payload.speculative_check_pr);
+    if (specLink) {
+        const wrap = document.createElement("span");
+        wrap.style.cssText = "margin-left:auto;";
+        wrap.appendChild(specLink);
+        row.appendChild(wrap);
+    }
+    return row;
+}
+
+function buildMergedRow() {
+    const row = document.createElement("div");
+    row.style.cssText =
+        "display:flex;align-items:center;gap:12px;padding:var(--base-size-16,16px)!important;";
+    row.appendChild(buildStatePill("merged"));
+    const msg = document.createElement("span");
+    msg.setAttribute("data-mergify-merged-msg", "");
+    msg.style.cssText = "color:#7d8590;font-size:12px;";
+    msg.textContent = getMergedMessage();
+    row.appendChild(msg);
+    row.appendChild(buildBrandAndLinks());
+    return row;
+}
+
+function deriveQueueButtonStateFromPayload(state) {
+    if (state === "checking" || state === "frozen" || state === "bisecting")
+        return "queued";
+    return "unqueued";
+}
+
+export function buildRichRow(payload, variant = "default") {
+    ensurePulseKeyframes();
+    const data = getPullRequestData();
+    const row = document.createElement("div");
+    row.setAttribute(MERGE_BOX_ROW_ATTR, variant);
+    row.dataset.mergifyShape = "rich";
+    row.className =
+        variant === "sidebar"
+            ? "border-top border-bottom color-border-subtle"
+            : "bgColor-muted borderColor-muted border-top rounded-bottom-2";
+
+    if (payload.state === "merged") {
+        row.appendChild(buildMergedRow());
+        return row;
+    }
+
+    const queueBtnState = deriveQueueButtonStateFromPayload(payload.state);
+    row.appendChild(buildButtonsRow(queueBtnState));
+    row.appendChild(buildStateRow(payload, data.org, data.repo));
+
+    const conditions = renderConditionsBlock(payload.required_conditions);
+    if (conditions) row.appendChild(conditions);
+
+    return row;
+}
+
+let _etaTimer = null;
+let _etaPayload = null;
+
+function _tickAllEtaMetas() {
+    if (!_etaPayload) {
+        stopEtaTicker();
+        return;
+    }
+    const metas = document.querySelectorAll(
+        `[${MERGE_BOX_ROW_ATTR}] [data-mergify-eta]`,
+    );
+    if (metas.length === 0) {
+        // No live rows to tick anymore (all detached).
+        stopEtaTicker();
+        return;
+    }
+    for (const meta of metas) {
+        meta.replaceChildren(...buildEtaMetaContent(_etaPayload));
+    }
+}
+
+export function startEtaTicker(payload) {
+    stopEtaTicker();
+    if (!payload?.estimated_time_of_merge) return;
+    _etaPayload = payload;
+    _etaTimer = setInterval(_tickAllEtaMetas, 1000);
+}
+
+export function stopEtaTicker() {
+    if (_etaTimer != null) {
+        clearInterval(_etaTimer);
+        _etaTimer = null;
+    }
+    _etaPayload = null;
 }


### PR DESCRIPTION
Engine PR Mergifyio/monorepo#32922 embeds a JSON merge-queue state payload
in the MQ status comment (it can't live in the check-run summary because
GitHub trims that HTML, and the check-runs API needs auth the extension
doesn't have). The marker block lands in the conversation DOM — but
GitHub's markdown sanitizer strips HTML comments from the *rendered*
timeline. The raw markdown source does survive in the inline edit-form
`<textarea class="CommentBox-input">` GitHub hydrates for inline editing,
and is also fetchable via `/issue_comments/<id>/edit_form` for comments
whose textarea isn't materialized — same pattern stacks.js already uses
for stack comments.

## What ships

**src/mqPayload.js (new)** — finds the latest Mergify status comment
across `.TimelineItem` nodes (reverse walk to skip Mergify-authored
non-status events that come after), parses the marker block, exposes
`attach(callback) / detach() / getCurrent()`. Live updates via a
MutationObserver on `document.body` (debounced 800ms, short-circuits
once in payload mode since the engine edits the same comment in place)
plus a 15s periodic poll as the safety net (inline `.value` mutations
on a `<textarea>` don't fire MutationObserver). Falls back to the
existing `/checks-page` scrape when no Mergify status comment exists
(`status_comments: none`, older on-prem engines, pre-comment window),
and upgrades to payload mode automatically as soon as one appears.
Two generation counters guard against stale in-flight emits across
detach or upgrade transitions.

**src/queue.js** — new "rich" row rendered from the payload: yellow
CI-in-progress Checking pill (amber Frozen, red Bisecting, green
Merged, red Dequeued, grey Waiting), live ETA countdown, Mergify-
branded state row, Batch PR button for the speculative-check PR,
and a compact "Blocking the merge (N):" list of unmet conditions
(met conditions skipped entirely; "any of" / "not" groups collapse
to a single inline row so the disjunction stays visible). The old
single-row layout becomes the "legacy" shape when no payload is
available. `buildMergifyRow(variant)` / `updateMergifyRow(row)`
keep PR #494's variant-based identity (`MERGE_BOX_ROW_ATTR`) and
dispatch internally to rich-vs-legacy based on `mqPayload.getCurrent()`.

**src/mergify.js** — subscribes via `mqPayload.attach`, runs alongside
PR #494's `fetchQueueStateIfNeeded` + `scheduleQueueStatePoll` so the
legacy poll path keeps driving updates when no payload exists. Side
peek + bottom mergebox stay in sync via `updateAllMergifyRows`.
`resetForNavigation` tears down mqPayload alongside the existing
queue/stack reset.

## Test surface

224 unit tests across 4 suites (Jest + jsdom). Coverage includes:
parser/regex edge cases, the textarea finder with inline + edit_form
fallback, attach/detach lifecycle including race-condition regressions
(zombie poll after upgrade, stale emit after detach), conditions block
rendering for met/unmet/any-of/all-of, ETA formatter boundaries, rich
row rendering for all six states, ETA ticker that fans out to all
mounted rows, multi-variant identity.

## Verified on

- #33609 (queued/checking with ETA + Batch PR)
- #32178 (in queue, edit_form fallback path exercised)
- #32275 (no MQ status comment → legacy fallback)
- Side peek opened from "View status" button shows the same row as the
  bottom mergebox

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>