### PR TITLE
fix(timestamps): drop help cursor on converted timestamps

### DIFF
--- a/src/__tests__/mergify.test.js
+++ b/src/__tests__/mergify.test.js
@@ -964,7 +964,8 @@ describe("convertMergifyTimestamps", () => {
         expect(codes[0].textContent).not.toBe("2025-06-15 14:30 UTC");
         expect(codes[0].getAttribute("title")).toBe("2025-06-15 14:30 UTC");
         expect(codes[1].getAttribute("title")).toBe("2025-06-15 16:00 UTC");
-        expect(codes[1].style.cursor).toBe("help");
+        // No forced cursor: converted timestamps match GitHub's native ones.
+        expect(codes[1].style.cursor).toBe("");
     });
 
     it("should not convert timestamps in non-Mergify comments", () => {

--- a/src/timestamps.js
+++ b/src/timestamps.js
@@ -27,6 +27,5 @@ export function convertMergifyTimestamps() {
         code.textContent = formatLocalTime(date);
         code.setAttribute(TIMESTAMP_CONVERTED_ATTR, "true");
         code.setAttribute("title", originalUtc);
-        code.style.cursor = "help";
     }
 }


### PR DESCRIPTION
The help cursor (circle-with-question-mark in Firefox) mis-signals a
timestamp as annotated jargon and diverges from GitHub's native
relative-time elements, which use the default cursor. The original UTC
value stays available via the title tooltip.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

Claude-Session-Id: 495eb618-1fd4-4dec-a0a3-492f035d5347