### PR TITLE
feat(queue): refresh queue state on tab focus/visibility

### DIFF
--- a/src/__tests__/mqPayload.test.js
+++ b/src/__tests__/mqPayload.test.js
@@ -283,7 +283,7 @@ describe("resolveLatestStatusCommentPayload", () => {
     });
 });
 
-const { attach, detach, getCurrent } = require("../mqPayload");
+const { attach, detach, getCurrent, refreshNow } = require("../mqPayload");
 
 const VALID_PAYLOAD = {
     version: 1,
@@ -564,5 +564,111 @@ describe("attach/detach — fallback + upgrade", () => {
         expect(calls.slice(payloadIdx).every((s) => s === "payload")).toBe(
             true,
         );
+    });
+});
+
+describe("refreshNow — immediate focus/visibility refresh", () => {
+    // The fallback-mode test assigns global.fetch directly;
+    // jest.restoreAllMocks() only restores spyOn spies, not direct property
+    // assignments, so capture and restore the original ourselves to avoid
+    // leaking the mock into later tests.
+    let originalFetch;
+    beforeEach(() => {
+        document.body.innerHTML = "";
+        window.history.replaceState({}, "", "/acme/widget/pull/42");
+        originalFetch = global.fetch;
+        detach();
+    });
+
+    afterEach(() => {
+        detach();
+        global.fetch = originalFetch;
+        jest.restoreAllMocks();
+    });
+
+    test("is a no-op when not attached", async () => {
+        await expect(refreshNow()).resolves.toBeUndefined();
+    });
+
+    test("does nothing when not on a pull request page", async () => {
+        window.history.replaceState({}, "", "/acme/widget/pulls");
+        appendInlineComment(VALID_PAYLOAD);
+        const cb = jest.fn();
+        attach(cb);
+        cb.mockClear();
+
+        await refreshNow();
+        expect(cb).not.toHaveBeenCalled();
+    });
+
+    test("payload mode: re-resolves and emits immediately without waiting for the poll", async () => {
+        const ta = appendInlineComment(VALID_PAYLOAD);
+        const cb = jest.fn();
+        attach(cb);
+        cb.mockClear();
+
+        // Engine rewrites the textarea `.value` (no DOM-tree mutation, so the
+        // MutationObserver won't catch it). refreshNow must pick it up right
+        // away instead of waiting for the next QUEUE_POLL_INTERVAL tick.
+        ta.value = markerFor({ ...VALID_PAYLOAD, state: "frozen" });
+        await refreshNow();
+
+        expect(cb).toHaveBeenCalledTimes(1);
+        expect(cb.mock.calls[0][0]).toEqual({
+            source: "payload",
+            payload: expect.objectContaining({ state: "frozen" }),
+        });
+    });
+
+    test("payload mode: does not re-emit when the payload is unchanged", async () => {
+        appendInlineComment(VALID_PAYLOAD);
+        const cb = jest.fn();
+        attach(cb);
+        cb.mockClear();
+
+        await refreshNow();
+        expect(cb).not.toHaveBeenCalled();
+    });
+
+    test("fallback mode: re-fetches the check-run queue state immediately", async () => {
+        let queued = false;
+        global.fetch = jest.fn((url) => {
+            const u = String(url);
+            if (u.includes("/checks")) {
+                return Promise.resolve({
+                    ok: true,
+                    text: () =>
+                        Promise.resolve(
+                            `<a href="?check_run_id=999"><span>Mergify Merge Queue</span></a>`,
+                        ),
+                });
+            }
+            if (u.includes("/runs/")) {
+                return Promise.resolve({
+                    ok: true,
+                    text: () =>
+                        Promise.resolve(
+                            queued ? "Queued for merge" : "Some other state",
+                        ),
+                });
+            }
+            // edit_form etc. — keep us in fallback mode.
+            return Promise.resolve({
+                ok: false,
+                text: () => Promise.resolve(""),
+            });
+        });
+
+        const cb = jest.fn();
+        attach(cb);
+        // Let the initial fallback poll settle (emits queued:false).
+        for (let i = 0; i < 10; i++) await Promise.resolve();
+        cb.mockClear();
+
+        // Queue state flips outside the page; focus refresh must observe it.
+        queued = true;
+        await refreshNow();
+
+        expect(cb).toHaveBeenCalledWith({ source: "fallback", queued: true });
     });
 });

--- a/src/mergify.js
+++ b/src/mergify.js
@@ -287,4 +287,29 @@ function onPageUpdate() {
         childList: true,
         subtree: true,
     });
+
+    // Force an immediate refresh when the tab regains focus or visibility. The
+    // periodic poll (QUEUE_POLL_INTERVAL) is the steady-state freshness
+    // mechanism, but browsers throttle timers in background tabs — so a PR page
+    // left in the background can show a stale queue button ("Add to" vs "Remove
+    // from merge queue") long after the queue changed via the CLI, a teammate's
+    // @mergifyio comment, or the engine merging it. Refreshing the moment the
+    // user looks back closes that window. mqPayload.refreshNow() routes to the
+    // active mode and emits through the same callback as the poll, so rows
+    // re-render only when something actually changed.
+    let refreshingOnFocus = false;
+    const refreshOnFocus = async () => {
+        if (document.visibilityState === "hidden") return;
+        if (!isGitHubPullRequestPage()) return;
+        // Coalesce focus + visibilitychange firing back-to-back into one fetch.
+        if (refreshingOnFocus) return;
+        refreshingOnFocus = true;
+        try {
+            await mqPayload.refreshNow();
+        } finally {
+            refreshingOnFocus = false;
+        }
+    };
+    document.addEventListener("visibilitychange", refreshOnFocus);
+    window.addEventListener("focus", refreshOnFocus);
 })();

--- a/src/mqPayload.js
+++ b/src/mqPayload.js
@@ -343,6 +343,29 @@ export function attach(callback) {
     }
 }
 
+// Force an immediate freshness pass, bypassing the periodic poll's timer.
+// Wired to tab focus / visibility-regain in the orchestrator: browsers
+// throttle setTimeout in background tabs, so a poll scheduled for
+// QUEUE_POLL_INTERVAL can be far staler than that by the time the user returns.
+// Re-resolving on focus makes the queue button reflect changes made outside the
+// page (a CLI dequeue, a teammate's @mergifyio command, the engine merging the
+// PR) the moment they look back at it.
+//
+// Routes to whichever mode is active, mirroring the periodic poll, and emits
+// through the same callback — so a row only re-renders when something actually
+// changed:
+//   - payload mode  → re-read the latest status-comment payload
+//   - fallback mode → re-fetch the check-run queue state
+export async function refreshNow() {
+    if (!_onChange) return;
+    if (!isGitHubPullRequestPage()) return;
+    if (_inPayloadMode) {
+        await _resolveAndEmit();
+    } else {
+        await _runFallbackPoll();
+    }
+}
+
 export function detach() {
     _payloadGeneration++;
     if (_timelineObserver) {


### PR DESCRIPTION
The merge-queue button ("Add to" / "Remove from merge queue") could go
stale when the queue changed outside the page — a CLI dequeue, a
teammate's @mergifyio command, or the engine merging the PR. The periodic
poll (QUEUE_POLL_INTERVAL, 15s) is the steady-state freshness mechanism,
but browsers throttle setTimeout in background tabs, so a PR page left in
the background could stay stale far longer than 15s.

Force an immediate refresh the moment the tab regains focus or
visibility:

- mqPayload.refreshNow() does an immediate freshness pass, routing to
  whichever mode is active (mirroring the periodic poll) and emitting
  through the same callback so rows re-render only when something
  actually changed:
    - payload mode  -> re-read the latest status-comment payload
    - fallback mode -> re-fetch the check-run queue state
- mergify.js wires visibilitychange (document) + focus (window) to
  refreshNow(), guarded to skip when hidden/off a PR page and to
  coalesce the two events firing back-to-back into a single fetch.

Note: in payload mode the refresh re-reads GitHub's DOM, so it is only as
fresh as GitHub's own SPA has made the status comment; the fallback path
does a real network fetch and is fully authoritative on focus.

Tests: 5 new cases for refreshNow (no-op unattached / off-PR, payload
re-emit on change, no re-emit when unchanged, fallback re-fetch). Full
suite 242 passing, biome clean, esbuild bundle builds.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>