### PR TITLE
fix(queue): Use theme-adaptive color for queued time and merge ETA

### DIFF
--- a/src/queue.js
+++ b/src/queue.js
@@ -921,7 +921,7 @@ function buildEtaMetaContent(payload) {
         frag.appendChild(document.createTextNode("queued "));
         const queuedMin = (Date.now() - Date.parse(payload.queued_at)) / 60000;
         const strong = document.createElement("strong");
-        strong.style.color = "#e6edf3";
+        strong.style.color = "var(--fgColor-default, #e6edf3)";
         strong.textContent = `${formatDurationMinutes(queuedMin)} ago`;
         frag.appendChild(strong);
         parts.push(frag);
@@ -931,7 +931,7 @@ function buildEtaMetaContent(payload) {
         const frag = document.createDocumentFragment();
         frag.appendChild(document.createTextNode("merging "));
         const strong = document.createElement("strong");
-        strong.style.color = "#e6edf3";
+        strong.style.color = "var(--fgColor-default, #e6edf3)";
         strong.textContent = etaStr;
         frag.appendChild(strong);
         parts.push(frag);


### PR DESCRIPTION
The queued-time and merge-ETA values in the merge-queue row hardcoded
#e6edf3 — GitHub's dark-mode foreground — so on a light background they
rendered as near-white-on-white and were effectively unreadable.

Switch both to var(--fgColor-default, #e6edf3), the theme-adaptive
pattern the rest of this row already uses, so the values stay emphasized
against the muted labels in both light and dark mode.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

Claude-Session-Id: d01080ea-0211-4306-98cc-c0586fa840b5