### PR TITLE
fix(queue): stop rich merge-queue row from freezing the page

### DIFF
--- a/src/__tests__/queue.test.js
+++ b/src/__tests__/queue.test.js
@@ -321,6 +321,84 @@ describe("buildMergifyRow dispatcher", () => {
     });
 });
 
+describe("updateMergifyRow rich-row idempotency (freeze regression #34031)", () => {
+    beforeEach(() => {
+        window.history.replaceState({}, "", "/acme/widget/pull/42");
+        document.body.innerHTML = "";
+        jest.resetModules();
+    });
+
+    function mockPayloadState(getState) {
+        jest.doMock("../mqPayload", () => ({
+            ...jest.requireActual("../mqPayload"),
+            getCurrent: () => ({
+                source: "payload",
+                payload: {
+                    version: 1,
+                    state: getState(),
+                    queue_rule_name: "default",
+                    queued_at: "2026-05-29T10:20:00Z",
+                    estimated_time_of_merge: "2026-05-29T10:42:00Z",
+                    speculative_check_pr: 12345,
+                    required_conditions: [],
+                },
+            }),
+        }));
+    }
+
+    // The freeze: _tryInject calls updateAllMergifyRows() on every body
+    // MutationObserver tick. If the rich path swaps the row's children on each
+    // call, replaceChildren is itself a tree mutation → re-fires the observer →
+    // self-sustaining rAF loop that pegs the main thread and destroys the row's
+    // buttons mid-click. An unchanged payload must be a DOM no-op.
+    test("repeated calls with an unchanged payload produce no DOM mutations", () => {
+        jest.isolateModules(() => {
+            mockPayloadState(() => "checking");
+            const queue = require("../queue");
+            const row = queue.buildMergifyRow();
+            document.body.appendChild(row);
+            expect(row.dataset.mergifyShape).toBe("rich");
+
+            const firstChildBefore = row.firstChild;
+            // Observe exactly what the body MutationObserver in mergify.js
+            // observes; takeRecords() returns synchronously whatever would have
+            // re-triggered the loop.
+            const observer = new MutationObserver(() => {});
+            observer.observe(document.body, { childList: true, subtree: true });
+
+            queue.updateMergifyRow(row);
+            queue.updateMergifyRow(row);
+
+            const records = observer.takeRecords();
+            observer.disconnect();
+
+            // No tree mutation → the orchestrator's observer would not re-fire.
+            expect(records).toHaveLength(0);
+            // And the existing buttons survive (a click can complete on them).
+            expect(row.firstChild).toBe(firstChildBefore);
+        });
+    });
+
+    test("still rebuilds when the payload state actually changes", () => {
+        jest.isolateModules(() => {
+            let state = "checking";
+            mockPayloadState(() => state);
+            const queue = require("../queue");
+            const row = queue.buildMergifyRow();
+            document.body.appendChild(row);
+            expect(
+                row.querySelector("[data-mergify-state-pill]").textContent,
+            ).toContain("Checking");
+
+            state = "frozen";
+            queue.updateMergifyRow(row);
+            expect(
+                row.querySelector("[data-mergify-state-pill]").textContent,
+            ).toContain("Frozen");
+        });
+    });
+});
+
 const { startEtaTicker, stopEtaTicker } = require("../queue");
 
 describe("ETA ticker", () => {

--- a/src/queue.js
+++ b/src/queue.js
@@ -623,12 +623,25 @@ export function updateMergifyRow(row) {
     }
 
     if (incomingShape === "rich") {
+        // Idempotency guard: skip the DOM swap when the row already reflects
+        // this payload. updateAllMergifyRows() runs on every tryInject tick
+        // (which fires from the body MutationObserver), so an unconditional
+        // replaceChildren here re-triggers that observer and spins a
+        // self-sustaining rAF loop — freezing the tab and eating clicks on
+        // the row's buttons. Time-based ETA text is owned by the ETA ticker,
+        // so it's intentionally excluded from the hash.
+        const newHash = _richRowHash(payload, variant, getPullRequestData());
+        if (row.getAttribute("data-mergify-hash") === newHash) {
+            _etaPayload = payload;
+            return;
+        }
         const next = buildRichRow(payload, variant);
         // Snapshot the children before replaceChildren starts moving them.
         // Spread already eagerly iterates, but Array.from makes the snapshot
         // explicit so the live-NodeList shape can't trip up a future reader
         // (or static analyzer) reasoning about iteration-during-mutation.
         row.replaceChildren(...Array.from(next.childNodes));
+        row.setAttribute("data-mergify-hash", newHash);
         _etaPayload = payload;
         debug("Mergify rich row patched:", payload.state);
         return;
@@ -1007,11 +1020,39 @@ function deriveQueueButtonStateFromPayload(state) {
     return "unqueued";
 }
 
+// Stable fingerprint of everything that determines a rich row's rendered
+// structure, EXCEPT the live ETA text (which the ETA ticker refreshes on its
+// own 1s cadence by touching only [data-mergify-eta]). updateMergifyRow uses
+// this to skip the children swap when nothing changed — without it, every
+// tryInject tick would replaceChildren, and since that is itself a tree
+// mutation observed by the orchestrator's body MutationObserver, it would
+// re-fire tryInject in a self-sustaining rAF loop that pegs the main thread
+// and destroys the row's buttons mid-click. Mirrors the data-mergify-hash
+// dedup already used by the stack-nav pill and context panel.
+function _richRowHash(payload, variant, data) {
+    const input = JSON.stringify({
+        v: variant,
+        org: data.org,
+        repo: data.repo,
+        s: payload.state,
+        q: payload.queued_at,
+        e: payload.estimated_time_of_merge,
+        spr: payload.speculative_check_pr,
+        rc: payload.required_conditions,
+    });
+    let h = 0;
+    for (let i = 0; i < input.length; i++) {
+        h = ((h << 5) - h + input.charCodeAt(i)) | 0;
+    }
+    return String(h);
+}
+
 export function buildRichRow(payload, variant = "default") {
     ensurePulseKeyframes();
     const data = getPullRequestData();
     const row = document.createElement("div");
     row.setAttribute(MERGE_BOX_ROW_ATTR, variant);
+    row.setAttribute("data-mergify-hash", _richRowHash(payload, variant, data));
     row.dataset.mergifyShape = "rich";
     row.className =
         variant === "sidebar"

--- a/src/queue.js
+++ b/src/queue.js
@@ -1034,6 +1034,11 @@ function _richRowHash(payload, variant, data) {
         v: variant,
         org: data.org,
         repo: data.repo,
+        // PR number is load-bearing: the queue/logs links and the merged
+        // message are all keyed on it. Omitting it would let a reused row
+        // survive an SPA nav between same-state PRs in one repo with stale
+        // links, since resetForNavigation doesn't tear the merge-box row down.
+        n: data.pull,
         s: payload.state,
         q: payload.queued_at,
         e: payload.estimated_time_of_merge,


### PR DESCRIPTION
## Problem

On PRs with an engine merge-queue payload comment (e.g. queued PRs like [monorepo#34031](https://github.com/Mergifyio/monorepo/pull/34031)), the page froze: clicking anything in the Mergify row — **Remove from merge queue, Refresh, Rebase, Update, the Mergify brand** — did nothing, as if the click never registered.

## Root cause

`updateAllMergifyRows()` runs on **every** `tryInject` tick, which fires from the body `MutationObserver`. The **rich-row** path in `updateMergifyRow` called `row.replaceChildren(...)` **unconditionally**. That swap is itself a tree mutation in the observed subtree, so it re-triggered the observer in a self-sustaining `requestAnimationFrame` loop:

```
MutationObserver → tryInject → updateAllMergifyRows → replaceChildren → (mutation) → MutationObserver → …
```

The loop pegged the main thread and rebuilt the row's buttons ~60×/sec, so a click could never survive `mousedown → mouseup` on the same node.

**Why only "some PRs":** the legacy row path is already idempotent, and the context panel + stack-nav pill both dedup via `data-mergify-hash`. The rich row (added in #522) was the one surface missing that guard.

## Fix

Give the rich row the same `data-mergify-hash` dedup used elsewhere in the codebase. `updateMergifyRow` now skips the children swap when the payload-derived fingerprint is unchanged. Live ETA text is intentionally excluded from the hash, since the ETA ticker already refreshes it on a 1s cadence by touching only `[data-mergify-eta]`.

## Tests

- New regression test reproduces the bug via `MutationObserver.takeRecords()`: a no-op rich-row update emitted **2** mutation records before the fix, **0** after.
- A companion test confirms a real state change (`checking → frozen`) still rebuilds, so the guard isn't over-aggressive.
- Full suite: **244/244 pass**; Biome lint clean; esbuild bundle compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)