### PR TITLE
ci(release): push to stores on publish

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,16 +23,35 @@ name: Release
 # Stage 2 — publish (`release: published`):
 #   Maintainer goes to Releases, reviews the draft (notes + asset
 #   list), optionally edits, clicks "Publish release". This fires
-#   `release: published`. We only ASSERT the three expected asset
+#   `release: published`. First we ASSERT the three expected asset
 #   names are present (sanity net if the release was created some
-#   other way, e.g. straight from the Releases UI without binaries),
-#   then exit. The release is immutable from this point on.
+#   other way, e.g. straight from the Releases UI without binaries).
+#   Then, gated on that assert, three independent jobs push the
+#   *reviewed bytes* to the stores — each downloads only its own asset
+#   off the published release and never rebuilds, so what ships equals
+#   what the maintainer reviewed:
+#     - Chrome Web Store: `chrome-webstore-upload-cli` uploads and
+#       publishes `mergify-chrome-<tag>.zip`.
+#     - Firefox AMO: `web-ext sign --channel listed` submits
+#       `mergify-firefox-<tag>.zip` for Mozilla's review queue. web-ext
+#       can only sign a *source directory*, never a prebuilt zip, so
+#       the reviewed asset is unzipped and web-ext repackages the same
+#       files — identical contents, fresh archive container.
+#     - Safari: `publish-safari-extension.sh` notarizes and staples
+#       `mergify-safari-<tag>.pkg`. Notarization runs post-publish, so
+#       the stapled pkg can't replace the immutable release asset; only
+#       the Apple-side notarization (Gatekeeper online check) persists.
+#       See RELEASING.md for that tradeoff.
+#   The three store jobs are independent: one failing doesn't block the
+#   others, and a red job flags exactly which store needs a manual
+#   retry. The release is immutable from this point on.
 #
-# Unlike the CLI, stage 2 does NOT publish anywhere: Chrome Web Store
-# / Firefox Add-ons uploads and Safari notarization
-# (`publish-safari-extension.sh`) stay manual, exactly as before.
-# Versions are explicit semver (no calver auto-compute) because the
-# web stores need monotonic version numbers under the existing scheme.
+# Store pushes only ever fire on Publish (never on the draft-building
+# dispatch stage) and only for full releases (pre-releases are
+# skipped), so a draft never reaches a public store — the human
+# draft→Publish gate is the whole point. Versions are explicit semver
+# (no calver auto-compute) because the web stores need monotonic
+# version numbers under the existing scheme.
 
 on:
   workflow_dispatch:
@@ -211,3 +230,150 @@ jobs:
             exit 1
           fi
           echo "All expected assets present."
+
+  # ---------------- Stage 2: push reviewed bytes to the stores ----------------
+  #
+  # All three jobs gate on `assert-assets-present` so a release missing its
+  # binaries never reaches a store, and skip pre-releases so only a real
+  # Publish ships. Each downloads only its own reviewed asset (no rebuild) and
+  # routes every secret/tag value through `env:` — never inline `${{ }}` in a
+  # `run:` body — so a hostile value can't break out of the shell.
+
+  publish-chrome:
+    name: publish to Chrome Web Store
+    needs: assert-assets-present
+    if: github.event_name == 'release' && github.event.action == 'published' && github.event.release.prerelease == false
+    runs-on: ubuntu-latest
+    permissions:
+      # Read-only: download the asset off the published release.
+      contents: read
+    steps:
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      - name: Download the reviewed Chrome asset
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ github.event.release.tag_name }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh release download "$TAG" --pattern "mergify-chrome-${TAG}.zip" --clobber
+
+      - name: Upload and publish to the Chrome Web Store
+        env:
+          # chrome-webstore-upload-cli reads CLIENT_ID/CLIENT_SECRET/
+          # REFRESH_TOKEN/EXTENSION_ID from the environment; the repo
+          # secrets are BROWSER_EXT_GOOGLE_*-named and mapped to those here.
+          CLIENT_ID: ${{ secrets.BROWSER_EXT_GOOGLE_CLIENT_ID }}
+          CLIENT_SECRET: ${{ secrets.BROWSER_EXT_GOOGLE_CLIENT_SECRET }}
+          REFRESH_TOKEN: ${{ secrets.BROWSER_EXT_GOOGLE_REFRESH_TOKEN_SILEHT }}
+          EXTENSION_ID: ${{ secrets.BROWSER_EXT_GOOGLE_EXTENSION_ID }}
+          TAG: ${{ github.event.release.tag_name }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          # No subcommand = upload + publish in one shot. v4 dropped the
+          # old `--auto-publish` flag (upload+publish is now the default
+          # when no command is given); pinned to major 4 so the CLI's
+          # contract can't shift under us.
+          npx --yes chrome-webstore-upload-cli@4 \
+            --source "mergify-chrome-${TAG}.zip" \
+            --extension-id "$EXTENSION_ID"
+
+  publish-firefox:
+    name: publish to Firefox Add-ons (AMO)
+    needs: assert-assets-present
+    if: github.event_name == 'release' && github.event.action == 'published' && github.event.release.prerelease == false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      - name: Download the reviewed Firefox asset
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ github.event.release.tag_name }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh release download "$TAG" --pattern "mergify-firefox-${TAG}.zip" --clobber
+
+      - name: Sign and submit to AMO (listed)
+        env:
+          # web-ext reads these exact env names for the AMO JWT creds.
+          WEB_EXT_API_KEY: ${{ secrets.BROWSER_EXT_MOZILLA_ISSUER }}
+          WEB_EXT_API_SECRET: ${{ secrets.BROWSER_EXT_MOZILLA_JWT_SECRET }}
+          TAG: ${{ github.event.release.tag_name }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          # web-ext can only sign a *source directory*, never a prebuilt
+          # zip, so unzip the reviewed asset and let web-ext repackage the
+          # identical files. `--channel listed` submits the version to
+          # Mozilla's review queue, which is human and asynchronous.
+          # `--approval-timeout 0` makes web-ext return as soon as the
+          # version is uploaded instead of blocking on approval — without
+          # it, web-ext waits up to 15 min and then *errors out* on the
+          # still-pending review, failing the job even though the submit
+          # succeeded.
+          rm -rf firefox-src
+          unzip -q "mergify-firefox-${TAG}.zip" -d firefox-src
+          npx --yes web-ext@10 sign \
+            --source-dir firefox-src \
+            --channel listed \
+            --approval-timeout 0
+
+  publish-safari:
+    name: notarize and staple the Safari pkg
+    needs: assert-assets-present
+    if: github.event_name == 'release' && github.event.action == 'published' && github.event.release.prerelease == false
+    # macOS runner: notarytool/stapler ship with Xcode, not on Linux.
+    runs-on: macos-15
+    permissions:
+      contents: read
+    steps:
+      # Check out at the release tag so publish-safari-extension.sh is the
+      # exact version that shipped, not whatever is on the default branch.
+      - uses: actions/checkout@v6.0.3
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Install the App Store Connect API key
+        env:
+          APPLE_CONNECT_KEY_P8: ${{ secrets.BROWSER_EXT_APPLE_CONNECT_KEY_P8 }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          # publish-safari-extension.sh hardcodes this path and the
+          # matching key id (ASA5Z72QVK); decode the base64 secret into it.
+          mkdir -p private_keys
+          echo "$APPLE_CONNECT_KEY_P8" | base64 --decode > private_keys/AuthKey_ASA5Z72QVK.p8
+
+      - name: Download the reviewed Safari asset
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ github.event.release.tag_name }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh release download "$TAG" --pattern "mergify-safari-${TAG}.pkg" --clobber
+
+      - name: Notarize and staple
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          # "We only need to run the script": it submits to notarytool
+          # --wait then staples the local copy. That stapled pkg can't be
+          # re-attached to the immutable release; the Apple-side
+          # notarization registration is what persists. See RELEASING.md.
+          ./publish-safari-extension.sh "./mergify-safari-${TAG}.pkg"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -38,18 +38,69 @@ merged since the previous tag. Takes ~10 minutes.
 4. Click **Publish release**.
 
 Publishing fires `release: published`, which runs the second half of
-the workflow: it asserts the three assets are present, then exits.
-The release is immutable from this point on.
+the workflow. It first asserts the three assets are present, then
+pushes those exact reviewed bytes to the three stores from three
+independent jobs (no rebuild). The release is immutable from this
+point on.
 
-## After publishing (manual)
+## What publishing pushes to the stores
 
-Publishing does **not** push to the stores or notarize. As today,
-once the release is published:
+The store jobs run only on Publish (never on the draft stage) and
+only for full releases — a release marked **pre-release** is skipped,
+so you can stage one without shipping it to the stores.
+
+- **Chrome Web Store** — `chrome-webstore-upload-cli` uploads
+  `mergify-chrome-<tag>.zip` and publishes it immediately.
+- **Firefox Add-ons (AMO)** — `web-ext sign --channel listed` submits
+  `mergify-firefox-<tag>.zip` to Mozilla's review queue. The job exits
+  as soon as the version is queued; Mozilla approval is asynchronous
+  and happens later on AMO. (web-ext can only sign a source directory,
+  so the job unzips the reviewed asset and web-ext repackages the same
+  files: identical contents, fresh archive container.)
+- **Safari** — `publish-safari-extension.sh` notarizes the pkg with
+  `notarytool --wait` and staples it. **Tradeoff:** notarization runs
+  *after* Publish, so the stapled pkg can't replace the asset already
+  attached to the now-immutable release. The GitHub `.pkg` stays
+  unstapled; what persists is the Apple-side notarization (Gatekeeper
+  verifies it via an online check, so the unstapled pkg still passes
+  on a machine with network access). Stapling here is only a no-op
+  belt-and-suspenders.
+
+The three jobs are independent: if one store fails (e.g. an expired
+token, a rejected version), the others still ship and the failed job
+goes red so you know exactly which store to retry. To retry a single
+store after a fix, re-run that one job from the Actions run.
+
+## Required store secrets
+
+These are repo **Actions secrets** (Settings → Secrets and variables →
+Actions). The release won't reach a store until its secrets are set;
+a missing secret just fails that one store's job.
+
+| Secret | Used by | What it is |
+| --- | --- | --- |
+| `BROWSER_EXT_GOOGLE_EXTENSION_ID` | Chrome | The extension's ID in the Web Store. |
+| `BROWSER_EXT_GOOGLE_CLIENT_ID` | Chrome | OAuth2 client ID for the Web Store API. |
+| `BROWSER_EXT_GOOGLE_CLIENT_SECRET` | Chrome | OAuth2 client secret. |
+| `BROWSER_EXT_GOOGLE_REFRESH_TOKEN_SILEHT` | Chrome | OAuth2 refresh token for the publishing account. |
+| `BROWSER_EXT_MOZILLA_ISSUER` | Firefox | AMO API key (JWT issuer), from addons.mozilla.org → Manage API Keys. |
+| `BROWSER_EXT_MOZILLA_JWT_SECRET` | Firefox | AMO API secret (JWT secret) for that key. |
+| `BROWSER_EXT_APPLE_CONNECT_KEY_P8` | Safari | Base64 of the App Store Connect API key `AuthKey_ASA5Z72QVK.p8`. Generate with `base64 -i AuthKey_ASA5Z72QVK.p8 \| pbcopy`. |
+
+The Apple **signing** secrets used by stage 1 (`APPLE_CERTIFICATE_P12`,
+`APPLE_CERTIFICATE_PASSWORD`) are unchanged. The team id, issuer id and
+key id are hardcoded in `publish-safari-extension.sh`; only the `.p8`
+key itself comes from the secret above.
+
+## Manual fallback
+
+If you need to push a store by hand (e.g. a job is red and you'd
+rather not re-run it), the original manual paths still work:
 
 - **Chrome Web Store** — upload `mergify-chrome-<tag>.zip` via the
   Web Store Developer Dashboard.
 - **Firefox Add-ons** — upload `mergify-firefox-<tag>.zip` via AMO.
-- **Safari** — notarize and staple the pkg:
+- **Safari** — notarize and staple the pkg locally:
   ```
   ./publish-safari-extension.sh ./mergify-safari-<tag>.pkg
   ```
@@ -66,7 +117,18 @@ once the release is published:
 
 ## If stage 2 fails
 
-The release is already published and immutable. The assert job only
-fails when artifacts are missing — i.e. the release was created
-outside the workflow. Delete the release and re-run stage 1 with the
-same tag.
+The release is already published and immutable, so what you do depends
+on *which* job went red.
+
+- **`assert artifacts attached` failed** — the release has no build
+  artifacts, i.e. it was created outside the workflow (e.g. straight
+  from the Releases UI). The store jobs are gated on this assert, so
+  they didn't run. Delete the release and re-run stage 1 with the same
+  tag.
+- **A store job failed** (`publish to Chrome Web Store`, `publish to
+  Firefox Add-ons (AMO)`, `notarize and staple the Safari pkg`) — the
+  release itself is fine; only that one store didn't get the new
+  version. Usually a bad/expired secret or a store-side rejection. Fix
+  the cause, then **re-run just that job** from the Actions run (or use
+  the manual fallback above). Do **not** delete the release — the other
+  stores already shipped and the bytes are immutable.


### PR DESCRIPTION
Extend Stage 2 (release: published) so that once the maintainer
publishes the draft, the already-reviewed artifacts are pushed to the
three stores, instead of only asserting they exist.

- Chrome Web Store: chrome-webstore-upload-cli uploads + publishes the
  reviewed mergify-chrome-<tag>.zip. v4 has no --auto-publish; the
  no-subcommand form does upload+publish in one shot.
- Firefox AMO: web-ext sign --channel listed submits the reviewed
  mergify-firefox-<tag>.zip to Mozilla's review queue. web-ext can only
  sign a source dir, so the zip is unzipped and repackaged (identical
  contents). --approval-timeout 0 avoids the 15-min wait that otherwise
  errors the job on the still-pending human review.
- Safari: publish-safari-extension.sh notarizes + staples
  mergify-safari-<tag>.pkg on macos-15. Notarization runs post-publish,
  so the stapled pkg can't replace the immutable release asset; the
  Apple-side notarization registration is what persists.

Each store is an independent job gated on the existing assert and on a
full (non-pre-release) publish, so one failing flags that store for a
manual re-run without blocking the others. Pushes never fire on the
draft/dispatch stage, keeping the draft->Publish review gate and
reusing the reviewed bytes (no rebuild). RELEASING.md documents the new
flow and the required store secrets.

Fixes MRGFY-7720