### PR TITLE
ci(mergify): drop duplicated review gates from default queue

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -27,10 +27,6 @@ queue_rules:
     <<: *DefaultQueueOptions
     queue_conditions:
       - and: *CheckRuns
-      - "#approved-reviews-by>=2"
-      - "#changes-requested-reviews-by=0"
-      - "#review-threads-unresolved=0"
-      - "#review-requested=0"
     merge_conditions:
       - and: *CheckRuns
 


### PR DESCRIPTION
The default queue rule duplicated the review requirement in its
queue_conditions (#approved-reviews-by>=2, #changes-requested-reviews-by=0,
#review-threads-unresolved=0, #review-requested=0). The Required Reviews
merge protection (if: [], with auto_merge_conditions: true) already enforces
the approval requirement at merge time, so route the default queue on CI
checks only and let the merge protection be the sole enforcer. Matches the
mergify-cli and monorepo pattern.

Fixes MRGFY-7755