### PR TITLE
ci(release): pass Chrome Web Store publisherId (API v2)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -265,12 +265,16 @@ jobs:
       - name: Upload and publish to the Chrome Web Store
         env:
           # chrome-webstore-upload-cli reads CLIENT_ID/CLIENT_SECRET/
-          # REFRESH_TOKEN/EXTENSION_ID from the environment; the repo
-          # secrets are BROWSER_EXT_GOOGLE_*-named and mapped to those here.
+          # REFRESH_TOKEN/EXTENSION_ID/PUBLISHER_ID from the environment; the
+          # repo secrets are BROWSER_EXT_GOOGLE_*-named and mapped to those.
+          # PUBLISHER_ID (the developer-account id, not the extension id) is
+          # required since cli@4 moved to the Chrome Web Store API v2, whose
+          # endpoints are scoped under publishers/<id>/items/<extension-id>.
           CLIENT_ID: ${{ secrets.BROWSER_EXT_GOOGLE_CLIENT_ID }}
           CLIENT_SECRET: ${{ secrets.BROWSER_EXT_GOOGLE_CLIENT_SECRET }}
           REFRESH_TOKEN: ${{ secrets.BROWSER_EXT_GOOGLE_REFRESH_TOKEN_SILEHT }}
           EXTENSION_ID: ${{ secrets.BROWSER_EXT_GOOGLE_EXTENSION_ID }}
+          PUBLISHER_ID: ${{ secrets.BROWSER_EXT_GOOGLE_PUBLISHER_ID }}
           TAG: ${{ github.event.release.tag_name }}
         shell: bash
         run: |

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -80,6 +80,7 @@ a missing secret just fails that one store's job.
 | Secret | Used by | What it is |
 | --- | --- | --- |
 | `BROWSER_EXT_GOOGLE_EXTENSION_ID` | Chrome | The extension's ID in the Web Store. |
+| `BROWSER_EXT_GOOGLE_PUBLISHER_ID` | Chrome | The developer-account (publisher) id, not the extension id. Required by the Web Store API v2. Find it in the dashboard URL: `chrome.google.com/webstore/devconsole/<publisher-id>`. |
 | `BROWSER_EXT_GOOGLE_CLIENT_ID` | Chrome | OAuth2 client ID for the Web Store API. |
 | `BROWSER_EXT_GOOGLE_CLIENT_SECRET` | Chrome | OAuth2 client secret. |
 | `BROWSER_EXT_GOOGLE_REFRESH_TOKEN_SILEHT` | Chrome | OAuth2 refresh token for the publishing account. |


### PR DESCRIPTION
chrome-webstore-upload-cli@4 uses chrome-webstore-upload@6, which moved
to the Chrome Web Store API v2 (publishers/<id>/items/<extension-id>)
and now requires a publisherId in addition to the OAuth creds. The
1.4.3 release failed with `Option "publisherId" is required`.

Wire PUBLISHER_ID from a new BROWSER_EXT_GOOGLE_PUBLISHER_ID secret (the
developer-account id, found in the dashboard URL) and document it.

Fixes MRGFY-7720