### PR TITLE
feat: grey out "Add to merge queue" for draft pull requests

### DIFF
--- a/src/__tests__/mergify.test.js
+++ b/src/__tests__/mergify.test.js
@@ -5,6 +5,7 @@ const {
     findTimelineActions,
     injectRowIntoMergeBox,
     isPullRequestOpen,
+    isPullRequestDraft,
     isPullRequestQueued,
     resetQueueState,
     findLastMergifyCommand,
@@ -433,6 +434,39 @@ describe("isPullRequestOpen", () => {
     });
 });
 
+describe("isPullRequestDraft", () => {
+    afterEach(() => {
+        document.body.innerHTML = "";
+    });
+
+    it("should detect draft PR via data-status=draft attribute", () => {
+        document.body.innerHTML = '<span data-status="draft">Draft</span>';
+        expect(isPullRequestDraft()).toBe(true);
+    });
+
+    it("should detect draft PR via legacy span.State title", () => {
+        document.body.innerHTML =
+            '<span class="State" title="Status: Draft">Draft</span>';
+        expect(isPullRequestDraft()).toBe(true);
+    });
+
+    it("should return false for an open PR", () => {
+        document.body.innerHTML = '<span data-status="pullOpened">Open</span>';
+        expect(isPullRequestDraft()).toBe(false);
+    });
+
+    it("should return false for an open legacy span.State", () => {
+        document.body.innerHTML =
+            '<span class="State" title="Status: Open">Open</span>';
+        expect(isPullRequestDraft()).toBe(false);
+    });
+
+    it("should return false when no status element is found", () => {
+        document.body.innerHTML = "<div>No status here</div>";
+        expect(isPullRequestDraft()).toBe(false);
+    });
+});
+
 describe("isPullRequestQueued", () => {
     afterEach(() => {
         document.body.innerHTML = "";
@@ -667,6 +701,42 @@ describe("deriveQueueButtonState", () => {
             </div>
         `;
         expect(deriveQueueButtonState()).toBe("unqueued");
+    });
+
+    it("should return 'draft' when PR is a draft", () => {
+        document.body.innerHTML = '<span data-status="draft">Draft</span>';
+        expect(deriveQueueButtonState()).toBe("draft");
+    });
+
+    it("should return 'draft' for a draft PR even with a pending queue command", () => {
+        document.body.innerHTML = `
+            <span data-status="draft">Draft</span>
+            <div class="TimelineItem">
+                <div class="comment-body">@mergifyio queue</div>
+            </div>
+        `;
+        expect(deriveQueueButtonState()).toBe("draft");
+    });
+
+    it("should return 'draft' from the legacy State badge title", () => {
+        document.body.innerHTML =
+            '<span class="State" title="Status: Draft">Draft</span>';
+        expect(deriveQueueButtonState()).toBe("draft");
+    });
+
+    it("should return 'queued' for a draft PR that is already in the queue so it keeps a dequeue button", () => {
+        document.body.innerHTML = `
+            <span data-status="draft">Draft</span>
+            <section aria-label="Checks">
+                <ul>
+                    <li>
+                        <span>Mergify Merge Queue</span>
+                        <span>— In merge queue</span>
+                    </li>
+                </ul>
+            </section>
+        `;
+        expect(deriveQueueButtonState()).toBe("queued");
     });
 
     it("should return 'merged' when PR merged by Mergify", () => {

--- a/src/__tests__/queue.test.js
+++ b/src/__tests__/queue.test.js
@@ -190,6 +190,13 @@ describe("buildRichRow", () => {
         window.history.replaceState({}, "", "/acme/widget/pull/42");
     });
 
+    afterEach(() => {
+        // deriveQueueButtonStateFromPayload reads the page DOM (draft status),
+        // so clear it between tests — otherwise a draft span set by one test
+        // would leak into the next and flip its expected button state.
+        document.body.innerHTML = "";
+    });
+
     test("renders checking state with pill, ETA, draft-PR link, and conditions block", () => {
         const row = buildRichRow(payload({ state: "checking" }));
         expect(row.dataset.mergifyShape).toBe("rich");
@@ -253,6 +260,20 @@ describe("buildRichRow", () => {
         expect(btn.getAttribute("data-mergify-queue-btn")).toBe("unqueued");
     });
 
+    test("draft PR renders a disabled add-to-queue button", () => {
+        document.body.innerHTML = '<span data-status="draft">Draft</span>';
+        const row = buildRichRow(
+            payload({
+                state: "dequeued",
+                required_conditions: [],
+                speculative_check_pr: null,
+            }),
+        );
+        const btn = row.querySelector("[data-mergify-queue-btn]");
+        expect(btn.getAttribute("data-mergify-queue-btn")).toBe("draft");
+        expect(btn.getAttribute("aria-disabled")).toBe("true");
+    });
+
     test("does not render draft-PR link when speculative_check_pr is null", () => {
         const row = buildRichRow(payload({ speculative_check_pr: null }));
         expect(row.querySelector("[data-mergify-spec-pr]")).toBeNull();
@@ -263,6 +284,45 @@ describe("buildRichRow", () => {
             payload({ speculative_check_pr: "12345; alert(1)" }),
         );
         expect(row.querySelector("[data-mergify-spec-pr]")).toBeNull();
+    });
+});
+
+const { buildQueueButton } = require("../queue");
+
+describe("buildQueueButton", () => {
+    test("draft state is greyed out via aria-disabled, keeps its tooltip, and ignores clicks", () => {
+        const btn = buildQueueButton("draft");
+        expect(btn.getAttribute("data-mergify-queue-btn")).toBe("draft");
+        // aria-disabled (not the `disabled` attribute) so the explanatory
+        // title tooltip still shows on hover — disabled controls suppress it.
+        expect(btn.getAttribute("aria-disabled")).toBe("true");
+        expect(btn.hasAttribute("disabled")).toBe(false);
+        expect(btn.getAttribute("title")).toContain("Draft pull requests");
+        expect(btn.style.opacity).toBe("0.5");
+        expect(btn.style.cursor).toBe("not-allowed");
+        expect(btn.textContent).toBe("Add to merge queue");
+
+        // Clicking must not post an @mergifyio queue command.
+        const field = document.createElement("input");
+        field.id = "new_comment_field";
+        document.body.appendChild(field);
+        btn.onclick(new MouseEvent("click"));
+        expect(field.value).toBe("");
+        document.body.innerHTML = "";
+    });
+
+    test("unqueued state is an enabled add-to-queue button", () => {
+        const btn = buildQueueButton("unqueued");
+        expect(btn.getAttribute("data-mergify-queue-btn")).toBe("unqueued");
+        expect(btn.hasAttribute("disabled")).toBe(false);
+        expect(btn.textContent).toBe("Add to merge queue");
+    });
+
+    test("queued state offers a remove button", () => {
+        const btn = buildQueueButton("queued");
+        expect(btn.getAttribute("data-mergify-queue-btn")).toBe("queued");
+        expect(btn.hasAttribute("disabled")).toBe(false);
+        expect(btn.textContent).toBe("Remove from merge queue");
     });
 });
 
@@ -303,6 +363,38 @@ describe("buildMergifyRow dispatcher", () => {
             expect(
                 row.querySelector("[data-mergify-state-pill]").textContent,
             ).toContain("Checking");
+        });
+    });
+
+    test("draft PR row swaps its disabled button for an enabled one when the PR becomes ready", () => {
+        jest.isolateModules(() => {
+            // No engine payload → legacy row path, where draft status drives
+            // the button.
+            jest.doMock("../mqPayload", () => ({
+                ...jest.requireActual("../mqPayload"),
+                getCurrent: () => null,
+            }));
+            const queue = require("../queue");
+
+            // Draft PR → legacy row with a greyed (aria-disabled) draft button.
+            document.body.innerHTML = '<span data-status="draft">Draft</span>';
+            const row = queue.buildMergifyRow();
+            document.body.appendChild(row);
+            let btn = row.querySelector("[data-mergify-queue-btn]");
+            expect(btn.getAttribute("data-mergify-queue-btn")).toBe("draft");
+            expect(btn.getAttribute("aria-disabled")).toBe("true");
+
+            // PR marked ready for review → status flips to open.
+            document
+                .querySelector("span[data-status]")
+                .setAttribute("data-status", "pullOpened");
+            queue.updateAllMergifyRows();
+
+            btn = row.querySelector("[data-mergify-queue-btn]");
+            expect(btn.getAttribute("data-mergify-queue-btn")).toBe("unqueued");
+            expect(btn.hasAttribute("aria-disabled")).toBe(false);
+
+            document.body.innerHTML = "";
         });
     });
 

--- a/src/queue.js
+++ b/src/queue.js
@@ -134,6 +134,18 @@ export function isPullRequestOpen() {
     return true;
 }
 
+export function isPullRequestDraft() {
+    if (document.querySelector("span[data-status=draft]")) return true;
+
+    const oldStatusBadge = document.querySelector("span.State");
+    if (oldStatusBadge) {
+        const status = oldStatusBadge.getAttribute("title")?.split(": ")[1];
+        if (status) return status.toLowerCase() === "draft";
+    }
+
+    return false;
+}
+
 export function wasMergedByMergify() {
     const timelineItems = document.querySelectorAll(".TimelineItem");
     for (const item of timelineItems) {
@@ -316,10 +328,20 @@ export function deriveQueueButtonState() {
     // Only show pending state when the command hasn't been acknowledged yet.
     // Once Mergify thumbs-ups the comment, it was processed — trust the check run.
     if (lastCmd && !lastCmd.acknowledged) {
-        if (lastCmd.command === "queue" && !checkRunQueued) return "queuing";
+        if (lastCmd.command === "queue" && !checkRunQueued) {
+            // A draft can't actually be queued, so don't show a perpetual
+            // "queuing…" spinner for a stale queue command on a draft.
+            return isPullRequestDraft() ? "draft" : "queuing";
+        }
         if (lastCmd.command === "dequeue" && checkRunQueued) return "dequeuing";
     }
-    return checkRunQueued ? "queued" : "unqueued";
+    if (checkRunQueued) return "queued";
+    // A draft PR that isn't queued can't be added — grey out the "Add to merge
+    // queue" action. Checked AFTER the queued/dequeue logic so a PR that's
+    // already in the queue keeps its dequeue affordance even as a draft (e.g.
+    // converted to draft while queued); draft only disables the add action.
+    if (isPullRequestDraft()) return "draft";
+    return "unqueued";
 }
 
 export function postCommand(command) {
@@ -413,6 +435,23 @@ export function buildQueueButton(state) {
                 true,
                 "secondary",
             );
+            break;
+        case "draft":
+            // Build it enabled (no `disabled` attribute) so the title tooltip
+            // still shows on hover — browsers suppress hover/pointer events on
+            // disabled controls, which would hide the explanation. Mark it
+            // aria-disabled, grey it out, and neutralize the click instead.
+            btn = buildMergeBoxButton(
+                "queue",
+                "Add to merge queue",
+                "Draft pull requests can't be queued — mark it ready for review first",
+                false,
+                "primary",
+            );
+            btn.setAttribute("aria-disabled", "true");
+            btn.style.opacity = "0.5";
+            btn.style.cursor = "not-allowed";
+            btn.onclick = (event) => event.preventDefault();
             break;
         case "queued":
             btn = buildMergeBoxButton(
@@ -1017,6 +1056,7 @@ function buildMergedRow() {
 function deriveQueueButtonStateFromPayload(state) {
     if (state === "checking" || state === "frozen" || state === "bisecting")
         return "queued";
+    if (isPullRequestDraft()) return "draft";
     return "unqueued";
 }
 
@@ -1044,6 +1084,11 @@ function _richRowHash(payload, variant, data) {
         e: payload.estimated_time_of_merge,
         spr: payload.speculative_check_pr,
         rc: payload.required_conditions,
+        // Draft status drives the queue button (draft → disabled). It lives in
+        // the page DOM, not the payload, so fold it in here; otherwise a
+        // draft→ready toggle that leaves the payload untouched would be deduped
+        // away and the button would stay greyed out.
+        d: isPullRequestDraft(),
     });
     let h = 0;
     for (let i = 0; i < input.length; i++) {


### PR DESCRIPTION
Draft PRs can't be queued, so the "Add to merge queue" button is now
disabled and greyed out while a PR is a draft, with a tooltip explaining
the PR must be marked ready for review first.

The button reacts to status changes: draft status is read on every
row-update tick (the existing MutationObserver/poll path), and it's
folded into the rich-row dedup hash so a draft→ready toggle that leaves
the engine payload untouched still re-renders the button instead of
being deduped away.

Draft only disables the *add* action. A PR that is already in the queue
keeps its "Remove from merge queue" button even if it's converted to a
draft while queued, so the dequeue affordance is never lost.

Test plan:
- npx jest (258 passing) — new coverage for isPullRequestDraft, the
  "draft" button state, draft→ready button swap, and the queued-draft
  keeps-dequeue case.
- npx biome check — clean.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>